### PR TITLE
release: bump 1.7.0 → 1.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # n-get — Agent Instructions
 
-**Version:** 1.7.0 · **License:** MIT · **Node:** >= 18
+**Version:** 1.8.0 · **License:** MIT · **Node:** >= 18
 
 Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,29 @@
+# Release Notes - v1.8.0
+
+## Overview
+Closes out the TypeScript migration for `lib/services/` started in 1.6.0, and locks down the public CLI contract (`--help`, `--capabilities`, `--openapi-spec`) with structural tests. Internal-only refactor — no public-surface changes.
+
+## 🚀 New Features
+- **`lib/services/` TypeScript migration complete** — `MetadataService`, `ResilientDownloadService`, `OutputFormatterService`, `CapabilitiesService`, `OpenAPIService` all ported to `.ts` in dependency order. Pure migration, no logic changes. Every service in the directory is now TS-sourced.
+- **CLI contract tests** (`test/cliOutputContractSpec.js`) — 20 structural assertions on `--help`, `--capabilities`, and `--openapi-spec` output. Strong-patterns approach: catches real regressions (missing flag, malformed JSON, version mismatch); tolerates cosmetic edits (spacing, emoji, copy tweaks).
+- **AGENTS.md freshness test** is now line-ending tolerant (Windows checkouts with `core.autocrlf=true` no longer fail the drift guard for cosmetic reasons).
+
+## 🔧 Developer Experience
+- 5 service files now type-checked (loosely — project-wide `strict: false` remains; per-file tightening is a separate future concern).
+- Test count: 420 passing (was 400 in 1.7.0; +20 new CLI contract assertions).
+
+## 💔 Breaking Changes
+None. CLI surface, library exports, NDJSON event names, and all flag contracts unchanged. `require('n-get')` still returns `{ fetch, capabilities, openapi, instructions, version }`.
+
+## Versioned surface (per SemVer)
+No public-surface changes. SemVer minor bump for the new test infrastructure (additive) and the internal refactor.
+
+---
+
+**Full Changelog**: [Compare v1.7.0...v1.8.0](https://github.com/bingeboy/n-get/compare/v1.7.0...v1.8.0)
+
+---
+
 # Release Notes - v1.7.0
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n-get",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "homepage": "https://bingeboy.github.io/n-get/",
   "description": "Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.",
   "repository": {


### PR DESCRIPTION
- package.json: version 1.7.0 → 1.8.0 (SemVer minor — backwards-compatible internal refactor: TS migration of remaining lib/services/* plus new CLI contract test suite. No public-surface changes.)
- RELEASE_NOTES.md: 1.8.0 entry summarizing the merged PR #91 scope.
- AGENTS.md: regenerated via npm run build:docs to reflect the new version in the header.