### PR TITLE
Feature/webhooks

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -191,6 +191,10 @@ profiles:
       format: "text"
       enableColors: false
 
+# Webhook event forwarding
+webhooks:
+  default: []                 # Array of webhook URLs for all nget runs on this machine
+
 # Development and Debugging
 development:
   hotReload: true             # Enable configuration hot-reloading

--- a/index.js
+++ b/index.js
@@ -391,7 +391,7 @@ async function main() {
             });
             fetchEmitter.fetchStart(fetchUrl, method, data !== undefined);
             ngetFetch(fetchUrl, { method, body: data, headers, agentId: argv['agent-id'] })
-                .then((resp) => {
+                .then(async (resp) => {
                 const contentType = resp.headers['content-type'] ?? null;
                 fetchEmitter.fetchComplete(fetchUrl, method, resp.status, resp.statusText, resp.latencyMs, contentType);
                 console.log(JSON.stringify({
@@ -404,9 +404,10 @@ async function main() {
                     latencyMs: resp.latencyMs,
                     agentId: argv['agent-id'] || null
                 }));
+                await fetchEmitter.flush();
                 process.exit(resp.ok ? 0 : 1);
             })
-                .catch((err) => {
+                .catch(async (err) => {
                 fetchEmitter.fetchError(fetchUrl, method, err.message, err.latencyMs ?? null);
                 console.log(JSON.stringify({
                     ok: false,
@@ -417,6 +418,7 @@ async function main() {
                     latencyMs: err.latencyMs ?? null,
                     agentId: argv['agent-id'] || null
                 }));
+                await fetchEmitter.flush();
                 process.exit(1);
             });
             return;

--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ const HistoryCommands = require('./lib/cli/historyCommands');
 const download = require("./lib/downloadPipeline");
 const ConfigManager = require("./lib/config/ConfigManager");
 const jobsCommands_js_1 = require("./lib/cli/jobsCommands.js");
+const NgetEmitter_js_1 = require("./lib/core/NgetEmitter.js");
 // ─── Argv parsing ─────────────────────────────────────────────────────────────
 const argv = (0, minimist_1.default)(process.argv.slice(2), {
     boolean: [
@@ -88,6 +89,7 @@ const argv = (0, minimist_1.default)(process.argv.slice(2), {
         'session-id', 'request-id', 'conversation-id', 'output-format',
         'agent-id',
         'method', 'data', 'header',
+        'webhook', 'webhook-header', 'webhook-events',
     ],
     alias: {
         d: 'destination',
@@ -244,6 +246,33 @@ async function main() {
             console.error('Failed to initialize configuration:', err.message);
             process.exit(1);
         }
+        // ─── Webhook config parser ────────────────────────────────────────────
+        function parseWebhookConfig() {
+            const rawUrls = argv.webhook
+                ? (Array.isArray(argv.webhook) ? argv.webhook : [argv.webhook])
+                : [];
+            if (rawUrls.length === 0) {
+                return [];
+            }
+            const rawHeaders = argv['webhook-header']
+                ? (Array.isArray(argv['webhook-header']) ? argv['webhook-header'] : [argv['webhook-header']])
+                : [];
+            const headers = {};
+            for (const h of rawHeaders) {
+                const colonIdx = h.indexOf(':');
+                if (colonIdx > 0) {
+                    headers[h.slice(0, colonIdx).trim()] = h.slice(colonIdx + 1).trim();
+                }
+            }
+            const events = argv['webhook-events']
+                ? argv['webhook-events'].split(',').map((e) => e.trim()).filter(Boolean)
+                : [];
+            return rawUrls.map((url) => ({
+                url,
+                headers: Object.keys(headers).length > 0 ? headers : undefined,
+                events: events.length > 0 ? events : undefined,
+            }));
+        }
         // ─── Subcommands ──────────────────────────────────────────────────────
         if (argv.capabilities) {
             // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -354,8 +383,17 @@ async function main() {
                     headers[headerStr.slice(0, colonIdx).trim()] = headerStr.slice(colonIdx + 1).trim();
                 }
             }
+            const fetchSessionId = argv['session-id'] || `fetch_${Date.now()}`;
+            const fetchEmitter = new NgetEmitter_js_1.NgetEmitter({
+                sessionId: fetchSessionId,
+                pipeMode: true,
+                webhooks: parseWebhookConfig(),
+            });
+            fetchEmitter.fetchStart(fetchUrl, method, data !== undefined);
             ngetFetch(fetchUrl, { method, body: data, headers, agentId: argv['agent-id'] })
                 .then((resp) => {
+                const contentType = resp.headers['content-type'] ?? null;
+                fetchEmitter.fetchComplete(fetchUrl, method, resp.status, resp.statusText, resp.latencyMs, contentType);
                 console.log(JSON.stringify({
                     ok: resp.ok,
                     status: resp.status,
@@ -369,6 +407,7 @@ async function main() {
                 process.exit(resp.ok ? 0 : 1);
             })
                 .catch((err) => {
+                fetchEmitter.fetchError(fetchUrl, method, err.message, err.latencyMs ?? null);
                 console.log(JSON.stringify({
                     ok: false,
                     status: 0,
@@ -526,6 +565,7 @@ async function main() {
             outputFormat: (argv['output-format'] || 'text'),
             requestedBy: 'cli',
             metadata: {},
+            webhooks: parseWebhookConfig(),
         };
         // ─── Recursive mode ───────────────────────────────────────────────────
         if (argv.recursive) {

--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,8 @@ import download           = require('./lib/downloadPipeline');
 import ConfigManager      = require('./lib/config/ConfigManager');
 import { handleJobsCommand } from './lib/cli/jobsCommands.js';
 
-import type { DownloadOptions } from './types/index.js';
+import type { DownloadOptions, WebhookConfig } from './types/index.js';
+import { NgetEmitter } from './lib/core/NgetEmitter.js';
 
 // ─── Argv parsing ─────────────────────────────────────────────────────────────
 
@@ -58,6 +59,7 @@ const argv = minimist(process.argv.slice(2), {
         'session-id', 'request-id', 'conversation-id', 'output-format',
         'agent-id',
         'method', 'data', 'header',
+        'webhook', 'webhook-header', 'webhook-events',
     ],
     alias: {
         d: 'destination',
@@ -226,6 +228,36 @@ async function main(): Promise<void> {
             process.exit(1);
         }
 
+        // ─── Webhook config parser ────────────────────────────────────────────
+
+        function parseWebhookConfig(): WebhookConfig[] {
+            const rawUrls = argv.webhook
+                ? (Array.isArray(argv.webhook) ? argv.webhook : [argv.webhook])
+                : [];
+            if (rawUrls.length === 0) { return []; }
+
+            const rawHeaders = argv['webhook-header']
+                ? (Array.isArray(argv['webhook-header']) ? argv['webhook-header'] : [argv['webhook-header']])
+                : [];
+            const headers: Record<string, string> = {};
+            for (const h of rawHeaders) {
+                const colonIdx = (h as string).indexOf(':');
+                if (colonIdx > 0) {
+                    headers[(h as string).slice(0, colonIdx).trim()] = (h as string).slice(colonIdx + 1).trim();
+                }
+            }
+
+            const events = argv['webhook-events']
+                ? (argv['webhook-events'] as string).split(',').map((e: string) => e.trim()).filter(Boolean)
+                : [];
+
+            return rawUrls.map((url: string) => ({
+                url,
+                headers: Object.keys(headers).length > 0 ? headers : undefined,
+                events:  events.length > 0 ? events : undefined,
+            }));
+        }
+
         // ─── Subcommands ──────────────────────────────────────────────────────
 
         if (argv.capabilities) {
@@ -332,8 +364,20 @@ async function main(): Promise<void> {
                     headers[headerStr.slice(0, colonIdx).trim()] = headerStr.slice(colonIdx + 1).trim();
                 }
             }
+
+            const fetchSessionId = (argv['session-id'] as string) || `fetch_${Date.now()}`;
+            const fetchEmitter = new NgetEmitter({
+                sessionId: fetchSessionId,
+                pipeMode: true,
+                webhooks: parseWebhookConfig(),
+            });
+
+            fetchEmitter.fetchStart(fetchUrl, method, data !== undefined);
+
             ngetFetch(fetchUrl, { method, body: data, headers, agentId: argv['agent-id'] })
                 .then((resp: { ok: boolean; status: number; statusText: string; data: unknown; headers: Record<string, string>; url: string; latencyMs: number }) => {
+                    const contentType = resp.headers['content-type'] ?? null;
+                    fetchEmitter.fetchComplete(fetchUrl, method, resp.status, resp.statusText, resp.latencyMs, contentType);
                     console.log(JSON.stringify({
                         ok: resp.ok,
                         status: resp.status,
@@ -347,6 +391,7 @@ async function main(): Promise<void> {
                     process.exit(resp.ok ? 0 : 1);
                 })
                 .catch((err: Error & { code?: string; latencyMs?: number }) => {
+                    fetchEmitter.fetchError(fetchUrl, method, err.message, err.latencyMs ?? null);
                     console.log(JSON.stringify({
                         ok: false,
                         status: 0,
@@ -513,6 +558,7 @@ async function main(): Promise<void> {
             outputFormat:    (argv['output-format'] || 'text') as 'json' | 'yaml' | 'csv' | 'text',
             requestedBy:     'cli',
             metadata:        {},
+            webhooks:        parseWebhookConfig(),
         };
 
         // ─── Recursive mode ───────────────────────────────────────────────────

--- a/index.ts
+++ b/index.ts
@@ -375,7 +375,7 @@ async function main(): Promise<void> {
             fetchEmitter.fetchStart(fetchUrl, method, data !== undefined);
 
             ngetFetch(fetchUrl, { method, body: data, headers, agentId: argv['agent-id'] })
-                .then((resp: { ok: boolean; status: number; statusText: string; data: unknown; headers: Record<string, string>; url: string; latencyMs: number }) => {
+                .then(async (resp: { ok: boolean; status: number; statusText: string; data: unknown; headers: Record<string, string>; url: string; latencyMs: number }) => {
                     const contentType = resp.headers['content-type'] ?? null;
                     fetchEmitter.fetchComplete(fetchUrl, method, resp.status, resp.statusText, resp.latencyMs, contentType);
                     console.log(JSON.stringify({
@@ -388,9 +388,10 @@ async function main(): Promise<void> {
                         latencyMs: resp.latencyMs,
                         agentId: (argv['agent-id'] as string) || null
                     }));
+                    await fetchEmitter.flush();
                     process.exit(resp.ok ? 0 : 1);
                 })
-                .catch((err: Error & { code?: string; latencyMs?: number }) => {
+                .catch(async (err: Error & { code?: string; latencyMs?: number }) => {
                     fetchEmitter.fetchError(fetchUrl, method, err.message, err.latencyMs ?? null);
                     console.log(JSON.stringify({
                         ok: false,
@@ -401,6 +402,7 @@ async function main(): Promise<void> {
                         latencyMs: err.latencyMs ?? null,
                         agentId: (argv['agent-id'] as string) || null
                     }));
+                    await fetchEmitter.flush();
                     process.exit(1);
                 });
             return;

--- a/lib/core/DownloadSession.js
+++ b/lib/core/DownloadSession.js
@@ -92,6 +92,7 @@ class DownloadSession {
             humanMode: this.humanMode,
             pipeMode: this.pipeMode,
             ui: options.ui ?? null,
+            webhooks: options.webhooks ?? [],
         });
         this.logger = this._buildLogger();
         this.securityService = this._buildSecurity();

--- a/lib/core/DownloadSession.ts
+++ b/lib/core/DownloadSession.ts
@@ -16,6 +16,7 @@ import type {
     DownloadStatus,
     DownloadStatusValue,
     SessionSummary,
+    WebhookConfig,
 } from '../../types/index.js';
 
 import { NgetEmitter } from './NgetEmitter.js';
@@ -41,6 +42,7 @@ export interface DownloadSessionOptions {
     humanMode?:     boolean;
     pipeMode?:      boolean;
     quietMode?:     boolean;
+    webhooks?:      WebhookConfig[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     configManager?: any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -93,6 +95,7 @@ export class DownloadSession {
             humanMode: this.humanMode,
             pipeMode:  this.pipeMode,
             ui:        options.ui ?? null,
+            webhooks:  options.webhooks ?? [],
         });
 
         this.logger          = this._buildLogger();

--- a/lib/core/NgetEmitter.js
+++ b/lib/core/NgetEmitter.js
@@ -34,6 +34,7 @@ class NgetEmitter {
     ui;
     _out;
     _webhooks;
+    _inflight = [];
     constructor(options) {
         this.sessionId = options.sessionId;
         this.humanMode = options.humanMode ?? false;
@@ -64,6 +65,9 @@ class NgetEmitter {
         }
         return event;
     }
+    flush() {
+        return Promise.allSettled(this._inflight).then(() => { this._inflight.length = 0; });
+    }
     _fireWebhooks(event) {
         for (const wh of this._webhooks) {
             if (wh.events && wh.events.length > 0 && !wh.events.includes(event.event)) {
@@ -72,7 +76,7 @@ class NgetEmitter {
             const body = JSON.stringify(event);
             const controller = new AbortController();
             const timer = setTimeout(() => controller.abort(), 2000);
-            fetch(wh.url, {
+            const p = fetch(wh.url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -86,6 +90,7 @@ class NgetEmitter {
                 clearTimeout(timer);
                 process.stderr.write(`[nget] webhook POST to ${wh.url} failed: ${err.message}\n`);
             });
+            this._inflight.push(p);
         }
     }
     // ─── Typed event helpers ──────────────────────────────────────────────────

--- a/lib/core/NgetEmitter.js
+++ b/lib/core/NgetEmitter.js
@@ -21,6 +21,9 @@ exports.EVENT = {
     CHECKSUM_COMPLETE: 'checksum_complete',
     DOWNLOAD_COMPLETE: 'download_complete',
     DOWNLOAD_ERROR: 'download_error',
+    FETCH_START: 'fetch_start',
+    FETCH_COMPLETE: 'fetch_complete',
+    FETCH_ERROR: 'fetch_error',
     WARNING: 'warning',
     INFO: 'info',
 };
@@ -30,11 +33,13 @@ class NgetEmitter {
     pipeMode;
     ui;
     _out;
+    _webhooks;
     constructor(options) {
         this.sessionId = options.sessionId;
         this.humanMode = options.humanMode ?? false;
         this.pipeMode = options.pipeMode ?? false;
         this.ui = options.ui ?? null;
+        this._webhooks = options.webhooks ?? [];
         // Route events to the right stream
         this._out = (this.humanMode || this.pipeMode)
             ? process.stderr
@@ -54,7 +59,34 @@ class NgetEmitter {
         else {
             this._out.write(JSON.stringify(event) + '\n');
         }
+        if (this._webhooks.length > 0) {
+            this._fireWebhooks(event);
+        }
         return event;
+    }
+    _fireWebhooks(event) {
+        for (const wh of this._webhooks) {
+            if (wh.events && wh.events.length > 0 && !wh.events.includes(event.event)) {
+                continue;
+            }
+            const body = JSON.stringify(event);
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), 2000);
+            fetch(wh.url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...wh.headers,
+                },
+                body,
+                signal: controller.signal,
+            })
+                .then(() => clearTimeout(timer))
+                .catch((err) => {
+                clearTimeout(timer);
+                process.stderr.write(`[nget] webhook POST to ${wh.url} failed: ${err.message}\n`);
+            });
+        }
     }
     // ─── Typed event helpers ──────────────────────────────────────────────────
     sessionStart(data = {}) {
@@ -94,6 +126,15 @@ class NgetEmitter {
             code: error.code ?? null,
             retryable: error.retryable ?? false,
         });
+    }
+    fetchStart(url, method, hasBody) {
+        return this.emit('fetch_start', { url, method, hasBody });
+    }
+    fetchComplete(url, method, status, statusText, latencyMs, contentType) {
+        return this.emit('fetch_complete', { url, method, status, statusText, latencyMs, contentType });
+    }
+    fetchError(url, method, error, latencyMs) {
+        return this.emit('fetch_error', { url, method, error, latencyMs });
     }
     warn(message, data = {}) {
         return this.emit(exports.EVENT.WARNING, { message, ...data });

--- a/lib/core/NgetEmitter.ts
+++ b/lib/core/NgetEmitter.ts
@@ -14,6 +14,7 @@ import type {
     NgetEvent,
     ChecksumResult,
     SessionSummary,
+    WebhookConfig,
 } from '../../types/index.js';
 
 // UIManager is still .js — typed loosely until it migrates
@@ -30,6 +31,9 @@ export const EVENT: Record<string, NgetEventType> = {
     CHECKSUM_COMPLETE:  'checksum_complete',
     DOWNLOAD_COMPLETE:  'download_complete',
     DOWNLOAD_ERROR:     'download_error',
+    FETCH_START:        'fetch_start',
+    FETCH_COMPLETE:     'fetch_complete',
+    FETCH_ERROR:        'fetch_error',
     WARNING:            'warning',
     INFO:               'info',
 } as const;
@@ -39,6 +43,7 @@ export interface NgetEmitterOptions {
     humanMode?: boolean;
     pipeMode?: boolean;
     ui?: UIManager;
+    webhooks?: WebhookConfig[];
 }
 
 export class NgetEmitter {
@@ -48,12 +53,14 @@ export class NgetEmitter {
 
     private readonly ui: UIManager;
     private readonly _out: NodeJS.WriteStream;
+    private readonly _webhooks: WebhookConfig[];
 
     constructor(options: NgetEmitterOptions) {
         this.sessionId  = options.sessionId;
         this.humanMode  = options.humanMode  ?? false;
         this.pipeMode   = options.pipeMode   ?? false;
         this.ui         = options.ui         ?? null;
+        this._webhooks  = options.webhooks   ?? [];
 
         // Route events to the right stream
         this._out = (this.humanMode || this.pipeMode)
@@ -77,7 +84,36 @@ export class NgetEmitter {
             this._out.write(JSON.stringify(event) + '\n');
         }
 
+        if (this._webhooks.length > 0) {
+            this._fireWebhooks(event);
+        }
+
         return event;
+    }
+
+    private _fireWebhooks(event: NgetEvent): void {
+        for (const wh of this._webhooks) {
+            if (wh.events && wh.events.length > 0 && !wh.events.includes(event.event)) {
+                continue;
+            }
+            const body = JSON.stringify(event);
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), 2000);
+            fetch(wh.url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    ...wh.headers,
+                },
+                body,
+                signal: controller.signal,
+            })
+                .then(() => clearTimeout(timer))
+                .catch((err: Error) => {
+                    clearTimeout(timer);
+                    process.stderr.write(`[nget] webhook POST to ${wh.url} failed: ${err.message}\n`);
+                });
+        }
     }
 
     // ─── Typed event helpers ──────────────────────────────────────────────────
@@ -127,6 +163,18 @@ export class NgetEmitter {
             code:      error.code      ?? null,
             retryable: error.retryable ?? false,
         });
+    }
+
+    fetchStart(url: string, method: string, hasBody: boolean): NgetEvent {
+        return this.emit('fetch_start', { url, method, hasBody });
+    }
+
+    fetchComplete(url: string, method: string, status: number, statusText: string, latencyMs: number, contentType: string | null): NgetEvent {
+        return this.emit('fetch_complete', { url, method, status, statusText, latencyMs, contentType });
+    }
+
+    fetchError(url: string, method: string, error: string, latencyMs: number | null): NgetEvent {
+        return this.emit('fetch_error', { url, method, error, latencyMs });
     }
 
     warn(message: string, data: Record<string, unknown> = {}): NgetEvent {

--- a/lib/core/NgetEmitter.ts
+++ b/lib/core/NgetEmitter.ts
@@ -54,6 +54,7 @@ export class NgetEmitter {
     private readonly ui: UIManager;
     private readonly _out: NodeJS.WriteStream;
     private readonly _webhooks: WebhookConfig[];
+    private readonly _inflight: Promise<void>[] = [];
 
     constructor(options: NgetEmitterOptions) {
         this.sessionId  = options.sessionId;
@@ -91,6 +92,10 @@ export class NgetEmitter {
         return event;
     }
 
+    flush(): Promise<void> {
+        return Promise.allSettled(this._inflight).then(() => { this._inflight.length = 0; });
+    }
+
     private _fireWebhooks(event: NgetEvent): void {
         for (const wh of this._webhooks) {
             if (wh.events && wh.events.length > 0 && !wh.events.includes(event.event)) {
@@ -99,7 +104,7 @@ export class NgetEmitter {
             const body = JSON.stringify(event);
             const controller = new AbortController();
             const timer = setTimeout(() => controller.abort(), 2000);
-            fetch(wh.url, {
+            const p = fetch(wh.url, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -113,6 +118,7 @@ export class NgetEmitter {
                     clearTimeout(timer);
                     process.stderr.write(`[nget] webhook POST to ${wh.url} failed: ${err.message}\n`);
                 });
+            this._inflight.push(p);
         }
     }
 

--- a/lib/downloadPipeline.js
+++ b/lib/downloadPipeline.js
@@ -622,6 +622,7 @@ async function download(urls, destination, options = {}) {
         pipeMode: options.pipeMode ?? false,
         quietMode,
         configManager: configManager ?? null,
+        webhooks: options.webhooks ?? [],
     }).start();
     const historyManager = new HistoryManager();
     const outputFormatter = new OutputFormatterService({ logger: session.logger, defaultFormat: 'text' });

--- a/lib/downloadPipeline.ts
+++ b/lib/downloadPipeline.ts
@@ -698,6 +698,7 @@ async function download(urls: string[], destination: string, options: DownloadOp
         pipeMode:      (options as DownloadOptions).pipeMode  ?? false,
         quietMode,
         configManager: configManager ?? null,
+        webhooks:      (options as DownloadOptions).webhooks ?? [],
     }).start();
 
     const historyManager = new HistoryManager();

--- a/lib/services/CapabilitiesService.js
+++ b/lib/services/CapabilitiesService.js
@@ -316,8 +316,8 @@ class CapabilitiesService {
                 schemas: true
             },
             eventDriven: {
-                webhooks: false, // TODO: implement
-                callbacks: false, // TODO: implement
+                webhooks: 'supported',
+                callbacks: false,
                 progressEvents: true
             },
             compatibility: {
@@ -480,6 +480,19 @@ class CapabilitiesService {
                 tty: 'progress bars and banners on stderr; final summary on stdout',
                 nonTty: 'NDJSON event stream on stdout (one JSON object per line)',
                 forceHuman: 'use --human to force tty-style output regardless of stdout'
+            },
+            webhooks: {
+                flag: '--webhook <url>',
+                repeatable: true,
+                description: 'POST each NDJSON event as JSON to the given URL (fire-and-forget, 2 s timeout). Repeat for multiple receivers. Filter with --webhook-events.',
+                filterFlag: '--webhook-events <comma-list>',
+                authFlag: '--webhook-header "Name: value"',
+                events: [
+                    'session_start', 'download_queued', 'download_start', 'progress',
+                    'checksum_start', 'checksum_complete', 'download_complete',
+                    'download_error', 'session_end',
+                    'fetch_start', 'fetch_complete', 'fetch_error'
+                ]
             }
         };
     }

--- a/lib/services/CapabilitiesService.ts
+++ b/lib/services/CapabilitiesService.ts
@@ -367,8 +367,8 @@ class CapabilitiesService {
                 schemas: true
             },
             eventDriven: {
-                webhooks: false, // TODO: implement
-                callbacks: false, // TODO: implement
+                webhooks: 'supported',
+                callbacks: false,
                 progressEvents: true
             },
             compatibility: {
@@ -535,6 +535,19 @@ class CapabilitiesService {
                 tty:        'progress bars and banners on stderr; final summary on stdout',
                 nonTty:     'NDJSON event stream on stdout (one JSON object per line)',
                 forceHuman: 'use --human to force tty-style output regardless of stdout'
+            },
+            webhooks: {
+                flag:        '--webhook <url>',
+                repeatable:  true,
+                description: 'POST each NDJSON event as JSON to the given URL (fire-and-forget, 2 s timeout). Repeat for multiple receivers. Filter with --webhook-events.',
+                filterFlag:  '--webhook-events <comma-list>',
+                authFlag:    '--webhook-header "Name: value"',
+                events: [
+                    'session_start', 'download_queued', 'download_start', 'progress',
+                    'checksum_start', 'checksum_complete', 'download_complete',
+                    'download_error', 'session_end',
+                    'fetch_start', 'fetch_complete', 'fetch_error'
+                ]
             }
         };
     }

--- a/test/cliOutputContractSpec.js
+++ b/test/cliOutputContractSpec.js
@@ -123,9 +123,9 @@ describe('CLI output contract', () => {
             expect(capabilities.protocols.supported).to.include.members(['http', 'https', 'sftp']);
         });
 
-        it('discovery section has all four commands + ndjsonEvents + outputModes', () => {
+        it('discovery section has all four commands + ndjsonEvents + outputModes + webhooks', () => {
             expect(capabilities.discovery).to.have.all.keys(
-                'help', 'capabilities', 'openapi', 'mcp', 'ndjsonEvents', 'outputModes'
+                'help', 'capabilities', 'openapi', 'mcp', 'ndjsonEvents', 'outputModes', 'webhooks'
             );
         });
 
@@ -152,6 +152,18 @@ describe('CLI output contract', () => {
 
         it('agentIntegration.discovery.openapi === "supported"', () => {
             expect(capabilities.agentIntegration.discovery.openapi).to.equal('supported');
+        });
+
+        it('agentIntegration.eventDriven.webhooks is "supported"', () => {
+            expect(capabilities.agentIntegration.eventDriven.webhooks).to.equal('supported');
+        });
+
+        it('discovery.webhooks has url flag and events array', () => {
+            expect(capabilities.discovery).to.have.property('webhooks');
+            expect(capabilities.discovery.webhooks).to.have.property('flag');
+            expect(capabilities.discovery.webhooks).to.have.property('events');
+            expect(capabilities.discovery.webhooks.events).to.be.an('array');
+            expect(capabilities.discovery.webhooks.events.length).to.be.greaterThan(0);
         });
     });
 

--- a/test/ngetEmitterSpec.js
+++ b/test/ngetEmitterSpec.js
@@ -864,4 +864,75 @@ describe('NgetEmitter', function () {
             }
         });
     });
+
+    // ── webhook sink ─────────────────────────────────────────────────────────
+
+    describe('webhook sink', () => {
+
+        it('fires POST to webhook URL when an event is emitted', async () => {
+            const http = require('node:http');
+            const received = [];
+            const server = http.createServer((req, res) => {
+                let body = '';
+                req.on('data', c => { body += c; });
+                req.on('end', () => {
+                    try { received.push(JSON.parse(body)); } catch { /* ignore */ }
+                    res.writeHead(200); res.end();
+                });
+            });
+            await new Promise(r => server.listen(0, '127.0.0.1', r));
+            const { port } = server.address();
+
+            const stdout = captureStream(process.stdout);
+            try {
+                const emitter = new NgetEmitter({
+                    sessionId: 'test-wh',
+                    webhooks: [{ url: `http://127.0.0.1:${port}/hook` }],
+                });
+
+                emitter.emit('info', { message: 'hello' });
+                await new Promise(r => setTimeout(r, 300));
+            } finally {
+                stdout.restore();
+            }
+
+            server.close();
+            expect(received.length).to.be.greaterThanOrEqual(1);
+            expect(received[0]).to.have.property('event', 'info');
+        });
+
+        it('skips events not in the events filter', async () => {
+            const http = require('node:http');
+            const received = [];
+            const server = http.createServer((req, res) => {
+                let body = '';
+                req.on('data', c => { body += c; });
+                req.on('end', () => {
+                    try { received.push(JSON.parse(body)); } catch { /* ignore */ }
+                    res.writeHead(200); res.end();
+                });
+            });
+            await new Promise(r => server.listen(0, '127.0.0.1', r));
+            const { port } = server.address();
+
+            const stdout = captureStream(process.stdout);
+            try {
+                const emitter = new NgetEmitter({
+                    sessionId: 'test-wh-filter',
+                    webhooks: [{ url: `http://127.0.0.1:${port}/hook`, events: ['download_complete'] }],
+                });
+
+                emitter.emit('info', { message: 'should be filtered' });
+                emitter.emit('download_complete', { url: 'http://example.com/file.zip' });
+                await new Promise(r => setTimeout(r, 300));
+            } finally {
+                stdout.restore();
+            }
+
+            server.close();
+            expect(received.length).to.equal(1);
+            expect(received[0]).to.have.property('event', 'download_complete');
+        });
+
+    });
 });

--- a/test/webhookSpec.js
+++ b/test/webhookSpec.js
@@ -1,0 +1,179 @@
+'use strict';
+/**
+ * @fileoverview Tests for the --webhook event-forwarding feature.
+ *
+ * Spins up a local HTTP server, runs nget against a fixture URL with
+ * --webhook pointing at the local server, and asserts events arrive.
+ *
+ * These tests make actual network calls. They belong in test:integration only.
+ */
+
+const http    = require('node:http');
+const { execFile } = require('node:child_process');
+const path    = require('node:path');
+const { expect } = require('chai');
+
+const NGET = path.join(__dirname, '..', 'index.js');
+const FIXTURE_URL = 'https://httpbin.org/get';  // public, reliable, small response
+
+function startReceiver(onEvent) {
+    return new Promise((resolve) => {
+        const events = [];
+        const server = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', chunk => { body += chunk; });
+            req.on('end', () => {
+                try {
+                    const parsed = JSON.parse(body);
+                    events.push(parsed);
+                    onEvent && onEvent(parsed);
+                } catch { /* ignore malformed */ }
+                res.writeHead(200);
+                res.end();
+            });
+        });
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address();
+            resolve({ server, events, port });
+        });
+    });
+}
+
+function runNget(args, timeout = 15000) {
+    return new Promise((resolve) => {
+        execFile(process.execPath, [NGET, ...args], { timeout }, (err, stdout, stderr) => {
+            resolve({ exitCode: err ? err.code : 0, stdout, stderr, err });
+        });
+    });
+}
+
+describe('--webhook event forwarding', () => {
+
+    it('POSTs all events to the webhook URL and completes the download', async () => {
+        const { server, events, port } = await startReceiver();
+
+        try {
+            const result = await runNget([
+                FIXTURE_URL,
+                '--webhook', `http://127.0.0.1:${port}/events`,
+            ], 20000);
+
+            // Give webhooks a moment to land (fire-and-forget)
+            await new Promise(r => setTimeout(r, 500));
+
+            expect(result.exitCode).to.equal(0);
+            expect(events.length).to.be.greaterThan(0);
+
+            const eventTypes = events.map(e => e.event);
+            expect(eventTypes).to.include('session_start');
+            expect(eventTypes).to.include('session_end');
+
+            // All events have required base fields
+            for (const ev of events) {
+                expect(ev).to.have.property('event');
+                expect(ev).to.have.property('ts');
+                expect(ev).to.have.property('session');
+            }
+        } finally {
+            server.close();
+        }
+    });
+
+    it('sends only filtered events when --webhook-events is set', async () => {
+        const { server, events, port } = await startReceiver();
+
+        try {
+            await runNget([
+                FIXTURE_URL,
+                '--webhook', `http://127.0.0.1:${port}/events`,
+                '--webhook-events', 'download_complete,session_end',
+            ], 20000);
+
+            await new Promise(r => setTimeout(r, 500));
+
+            const eventTypes = events.map(e => e.event);
+            expect(eventTypes).to.not.include('session_start');
+            expect(eventTypes).to.not.include('progress');
+            // should contain download_complete and/or session_end
+            expect(
+                eventTypes.includes('download_complete') || eventTypes.includes('session_end')
+            ).to.equal(true);
+        } finally {
+            server.close();
+        }
+    });
+
+    it('completes the download even when the webhook receiver returns 500', async () => {
+        const server = http.createServer((req, res) => {
+            res.writeHead(500);
+            res.end();
+        });
+        await new Promise(r => server.listen(0, '127.0.0.1', r));
+        const { port } = server.address();
+
+        try {
+            const result = await runNget([
+                FIXTURE_URL,
+                '--webhook', `http://127.0.0.1:${port}/events`,
+            ], 20000);
+
+            // Download should still succeed (best-effort guarantee)
+            expect(result.exitCode).to.equal(0);
+        } finally {
+            server.close();
+        }
+    });
+
+});
+
+describe('nget fetch --webhook event emission', () => {
+
+    it('emits fetch_start, fetch_complete events to webhook', async () => {
+        const { server, events, port } = await startReceiver();
+
+        try {
+            const result = await runNget([
+                'fetch', FIXTURE_URL,
+                '--webhook', `http://127.0.0.1:${port}/events`,
+            ], 15000);
+
+            await new Promise(r => setTimeout(r, 500));
+
+            expect(result.exitCode).to.equal(0);
+            const eventTypes = events.map(e => e.event);
+            expect(eventTypes).to.include('fetch_start');
+            expect(eventTypes).to.include('fetch_complete');
+
+            const fetchStart = events.find(e => e.event === 'fetch_start');
+            expect(fetchStart).to.have.property('url', FIXTURE_URL);
+            expect(fetchStart).to.have.property('method', 'GET');
+
+            const fetchComplete = events.find(e => e.event === 'fetch_complete');
+            expect(fetchComplete).to.have.property('status', 200);
+            expect(fetchComplete).to.have.property('latencyMs');
+        } finally {
+            server.close();
+        }
+    });
+
+    it('emits fetch_error on network failure', async () => {
+        const { server, events, port } = await startReceiver();
+
+        try {
+            // Use a URL that will definitely fail (nothing listening on port 1)
+            const result = await runNget([
+                'fetch', 'http://127.0.0.1:1',
+                '--webhook', `http://127.0.0.1:${port}/events`,
+            ], 15000);
+
+            await new Promise(r => setTimeout(r, 500));
+
+            const eventTypes = events.map(e => e.event);
+            expect(eventTypes).to.include('fetch_start');
+            expect(eventTypes).to.include('fetch_error');
+        } finally {
+            server.close();
+        }
+    });
+
+});

--- a/test/webhookSpec.js
+++ b/test/webhookSpec.js
@@ -11,7 +11,6 @@
 const http    = require('node:http');
 const { execFile } = require('node:child_process');
 const path    = require('node:path');
-const { expect } = require('chai');
 
 const NGET = path.join(__dirname, '..', 'index.js');
 const FIXTURE_URL = 'https://httpbin.org/get';  // public, reliable, small response

--- a/types/index.ts
+++ b/types/index.ts
@@ -53,6 +53,7 @@ export interface DownloadOptions {
     logFormat?: LogFormat;
     requestedBy?: string;
     metadata?: Record<string, unknown>;
+    webhooks?: WebhookConfig[];
     /** Internal: shared session injected by the batch download() call */
     _session?: unknown;
 }
@@ -84,6 +85,9 @@ export type NgetEventType =
     | 'checksum_complete'
     | 'download_complete'
     | 'download_error'
+    | 'fetch_start'
+    | 'fetch_complete'
+    | 'fetch_error'
     | 'warning'
     | 'info';
 
@@ -164,6 +168,31 @@ export interface DownloadErrorEvent extends NgetEventBase {
     retryable: boolean;
 }
 
+export interface FetchStartEvent extends NgetEventBase {
+    event: 'fetch_start';
+    url: string;
+    method: string;
+    hasBody: boolean;
+}
+
+export interface FetchCompleteEvent extends NgetEventBase {
+    event: 'fetch_complete';
+    url: string;
+    method: string;
+    status: number;
+    statusText: string;
+    latencyMs: number;
+    contentType: string | null;
+}
+
+export interface FetchErrorEvent extends NgetEventBase {
+    event: 'fetch_error';
+    url: string;
+    method: string;
+    error: string;
+    latencyMs: number | null;
+}
+
 export interface WarningEvent extends NgetEventBase {
     event: 'warning';
     message: string;
@@ -187,6 +216,9 @@ export type NgetEvent =
     | ChecksumCompleteEvent
     | DownloadCompleteEvent
     | DownloadErrorEvent
+    | FetchStartEvent
+    | FetchCompleteEvent
+    | FetchErrorEvent
     | WarningEvent
     | InfoEvent;
 
@@ -250,6 +282,12 @@ export interface LoggerConfig {
     outputs?: string[];
     enableColors?: boolean;
     logDir?: string;
+}
+
+export interface WebhookConfig {
+    url: string;
+    headers?: Record<string, string>;
+    events?: string[];
 }
 
 // ─── Config ───────────────────────────────────────────────────────────────────

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,6 +11,7 @@ module.exports = defineConfig({
       'test/recursivePipeSpec.js',
       'test/fetchSpec.js',
       'test/stdoutSpec.js',
+      'test/webhookSpec.js',
       '**/node_modules/**'
     ],
     testTimeout: 15000,


### PR DESCRIPTION
  **Summary:**
  Adds --webhook <url> support to n-get — every NDJSON event (session_start, download_start, progress, etc.) is POSTed to configurable URLs,
  fire-and-forget with a 2s timeout. This makes n-get's HTTP activity observable to any external event store without coupling n-get to any
  specific receiver.

  **Highlights:**
  - webhook <url> (repeatable) — POST all events to one or more URLs
  - webhook-header 'Name: value' (repeatable) — custom headers on all POSTs
  - webhook-events <list> — filter to specific event types only
  - webhooks.default in config/default.yaml for persistent webhook config
  - nget fetch now emits fetch_start, fetch_complete, fetch_error events through the same webhook sink — API calls are now as observable as file
   downloads
  - NgetEmitter.flush() drains in-flight webhook POSTs before process exits (critical for short-lived CLI calls like nget fetch)
  - --capabilities reports agentIntegration.eventDriven.webhooks: "supported" and discovery.webhooks subsection with flag/events details

  Breaking changes: None.