### PR TITLE
fix: use mkdtempSync in chdir/getDestination tests — remove hardcoded…

### DIFF
--- a/test/chdirSpec.js
+++ b/test/chdirSpec.js
@@ -1,39 +1,41 @@
+'use strict';
+const fs   = require('node:fs');
+const os   = require('node:os');
 const path = require('node:path');
 const chdir = require('../lib/chdir');
 
 describe('Chdir Module', () => {
     let originalCwd;
+    let tempDir;
 
     beforeEach(() => {
         originalCwd = process.cwd();
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nget-chdir-'));
     });
 
     afterEach(() => {
-        // Restore original working directory
         process.chdir(originalCwd);
+        try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
     });
 
     describe('#chdir()', () => {
         it('should change to valid directory and return new path', () => {
-            const tempDir = path.join(__dirname, '..', 'temp');
-            const result = chdir(tempDir);
-
+            const result = chdir(tempDir, true);
             expect(result).to.equal(tempDir);
             expect(process.cwd()).to.equal(tempDir);
         });
 
         it('should throw error for invalid directory', () => {
-            const invalidDir = '/nonexistent/directory';
-
-            expect(() => chdir(invalidDir)).to.throw();
+            expect(() => chdir('/nonexistent/directory/xyz', true)).to.throw();
         });
 
         it('should handle relative paths', () => {
-            const tempDir = './temp';
-            const result = chdir(tempDir);
-
-            expect(result).to.include('temp');
-            expect(process.cwd()).to.include('temp');
+            process.chdir(tempDir);
+            const subDir = fs.mkdtempSync(path.join(tempDir, 'sub-'));
+            const rel = path.relative(process.cwd(), subDir);
+            const result = chdir(rel, true);
+            expect(result).to.include('sub-');
+            expect(process.cwd()).to.include('sub-');
         });
     });
 });

--- a/test/getDestinationSpec.js
+++ b/test/getDestinationSpec.js
@@ -1,21 +1,25 @@
+'use strict';
+const fs   = require('node:fs');
+const os   = require('node:os');
 const path = require('node:path');
 const chdir = require('../lib/chdir.js');
 
 describe('Destination handling', () => {
     let originalCwd;
+    let tempDir;
 
     beforeEach(() => {
         originalCwd = process.cwd();
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nget-dest-'));
     });
 
     afterEach(() => {
-        // Restore original working directory
         process.chdir(originalCwd);
+        try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
     });
 
     it('should handle valid destination directory', () => {
-        const tempDir = path.join(__dirname, '..', 'temp');
-        const result = chdir(tempDir);
+        const result = chdir(tempDir, true);
         expect(result).to.equal(tempDir);
         expect(process.cwd()).to.equal(tempDir);
     });


### PR DESCRIPTION
… temp dir dependency

fixed tests no bueno. 200 all around mates.