### PR TITLE
release: bump 1.9.1 → 1.10.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # n-get — Agent Instructions
 
-**Version:** 1.9.1 · **License:** MIT · **Node:** >= 18
+**Version:** 1.10.0 · **License:** MIT · **Node:** >= 18
 
 Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,55 @@
+# Release Notes - v1.10.0
+
+## Overview
+Largest feature release since 1.7.0. Four additions land together: auto-generated `--help` (no more drift), webhook event forwarding for AI observability, five new MCP tools for agent-side session control, and a Vitest migration that cuts cold test time in half. All additive — no breaking changes.
+
+## New Features
+
+### Webhook event forwarding (`--webhook`)
+Every NDJSON event n-get emits (session_start, download_start, progress, download_complete, etc.) is now POSTed to configurable URLs in real time — fire-and-forget, 2 s timeout, best-effort. Pairs with any event store or agent orchestrator.
+
+- `--webhook <url>` (repeatable) — POST events to one or more receivers
+- `--webhook-header 'Name: value'` (repeatable) — custom headers on all POSTs
+- `--webhook-events <comma-list>` — filter to specific event types only
+- `webhooks.default` in config for persistent per-machine webhook registration
+- `nget fetch` now emits `fetch_start`, `fetch_complete`, `fetch_error` through the same sink — API calls are as observable as file downloads
+- `NgetEmitter.flush()` — drains in-flight POSTs before process exit (prevents lost events on fast `nget fetch` calls)
+- `--capabilities` reports `agentIntegration.eventDriven.webhooks: "supported"` and `discovery.webhooks` subsection
+
+### 5 new MCP tools
+The MCP server grows from 4 tools to 9. New tools give agents direct session control without subprocess spawning:
+
+| Tool | What it does |
+|---|---|
+| `cancel_session(sessionId)` | Kills a specific download session; others continue |
+| `get_session(sessionId)` | Returns full current state of one session |
+| `set_profile(profileName)` | Applies fast/secure/bulk/careful config profile process-wide |
+| `get_history(destination?, limit?, status?, since?)` | Flat MCP-schema download history |
+| `get_instructions()` | Returns AGENTS.md — the agent usage guide |
+
+Session cancellation is in-process and immediate: `cancel_session` sets a flag checked between downloads in any active batch; other sessions are unaffected.
+
+### Auto-generated `--help` (no more drift)
+`CapabilitiesService.getCLIFlags()` is now the single source of truth for all 32 CLI flags. `toHelpSummary()` derives `--help` output from it directly — the same way `toMarkdown()` drives AGENTS.md. A drift-guard test asserts every flag in `getCLIFlags()` appears in `--help` stdout.
+
+### Vitest migration
+Test runner replaced mocha + chai with Vitest. Cold run time: ~2 s (was ~8 s). Vitest globals (`describe`, `it`, `expect`, `beforeAll`, `afterAll`) available without imports; mocha-compat aliases (`before`/`after`) provided via setup file.
+
+## Bug fixes
+- `test/chdirSpec.js`, `test/getDestinationSpec.js`: replaced hardcoded `temp/` directory assumption with `fs.mkdtempSync` — tests were failing in any checkout where the `temp/` dir didn't exist
+
+## Breaking Changes
+None. All CLI flags, NDJSON event names, library exports, and MCP tool names from 1.9.1 are unchanged.
+
+## Tests
+449 passing, 0 failing (up from 420 in 1.8.0).
+
+---
+
+**Full Changelog**: [Compare v1.9.1...v1.10.0](https://github.com/bingeboy/n-get/compare/v1.9.1...v1.10.0)
+
+---
+
 # Release Notes - v1.8.0
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n-get",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "homepage": "https://bingeboy.github.io/n-get/",
   "description": "Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.",
   "repository": {


### PR DESCRIPTION
  Summary

  Bundles four features developed post-1.9.1: webhook event forwarding, 5 new MCP tools, auto-generated --help, and the Vitest test runner
  migration. One bug fix (chdir tests). All additive — no breaking changes.

  Highlights

  - --webhook <url> — POST every NDJSON event to configurable receivers (fire-and-forget, 2 s timeout); nget fetch now also emits
  fetch_start/fetch_complete/fetch_error
  - 5 new MCP tools: cancel_session, get_session, set_profile, get_history, get_instructions — agents now have direct session control via MCP
  without subprocess spawning
  - --help derives from CapabilitiesService.getCLIFlags() — same source as --capabilities and AGENTS.md; drift is caught by test
  - Vitest replaces mocha+chai; cold test run ~2 s vs ~8 s
  - chdir test fix: no more phantom temp/ directory dependency

  Breaking changes

  None.

  Commits

  ┌─────────┬───────────────────────────────────────────────────────────┐
  │   SHA   │                        Description                        │
  ├─────────┼───────────────────────────────────────────────────────────┤
  │ 4b1f28f │ Feature/auto help (#98)                                   │
  ├─────────┼───────────────────────────────────────────────────────────┤
  │ 34b12dd │ test: migrate test runner from mocha+chai to vitest (#99) │
  ├─────────┼───────────────────────────────────────────────────────────┤
  │ 4b4771d │ Feature/webhooks (#100)                                   │
  ├─────────┼───────────────────────────────────────────────────────────┤
  │ a97d896 │ feat(mcp): add 5 new MCP tools (#101)                     │
  ├─────────┼───────────────────────────────────────────────────────────┤
  │ ce62564 │ fix: chdir/getDestination test fix (#102)                 │
  ├─────────┼───────────────────────────────────────────────────────────┤
  │ 707ea23 │ release: bump 1.9.1 → 1.10.0                              │
  └─────────┴───────────────────────────────────────────────────────────┘

  Test plan

  - npm test — 449 passing, 0 failing
  - npm run build:docs — AGENTS.md regenerated (3148 bytes)
  - npm pack --dry-run — 64 files, 191 kB tarball, version 1.10.0 confirmed