### PR TITLE
release: 1.10.0 → 1.10.1 — README, security, TS source fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # n-get — Agent Instructions
 
-**Version:** 1.10.0 · **License:** MIT · **Node:** >= 18
+**Version:** 1.10.1 · **License:** MIT · **Node:** >= 18
 
 Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,26 @@
+# Release Notes - v1.10.1
+
+## Overview
+Patch release. No feature or API changes. Fixes 6 Dependabot security alerts (all devDependencies, never exposed to npm consumers) and replaces a stale README with accurate 1.10.0 documentation.
+
+## Changes
+
+- **README overhaul** — quick start fixed (`nget --stdout` never existed; replaced with `nget fetch`), webhook flags documented, all 12 NDJSON events listed (including `fetch_start/complete/error`), all 9 MCP tools listed, programmatic API path corrected (`require('n-get/lib/fetch')` → `const { fetch } = require('n-get')`), logo replaced with Zalgo ASCII heading
+- **Security: prune orphaned mocha tree** — mocha was removed from `package.json` during the 1.10.0 vitest migration but left in `node_modules`; `npm prune` removed it and its transitive dep `serialize-javascript` (high-severity RCE + DoS CVEs)
+- **Security: update transitive devDeps** — `npm audit fix` updated `hono`, `express-rate-limit`, `ip-address`; 0 vulnerabilities remaining
+
+## Breaking Changes
+None.
+
+## Tests
+449 passing, 0 failing — unchanged from 1.10.0.
+
+---
+
+**Full Changelog**: [Compare v1.10.0...v1.10.1](https://github.com/bingeboy/n-get/compare/v1.10.0...v1.10.1)
+
+---
+
 # Release Notes - v1.10.0
 
 ## Overview

--- a/lib/downloadPipeline.js
+++ b/lib/downloadPipeline.js
@@ -652,7 +652,7 @@ async function download(urls, destination, options = {}) {
         try {
             if (options.session?.isCancelled()) {
                 const err = Object.assign(new Error('Download cancelled'), { code: 'CANCELLED' });
-                session.failDownload(url, err);
+                options.session.failDownload(url, err);
                 return { url, error: err.message, success: false };
             }
             const downloadResult = await concurrencyLimiter.execute(downloadFile, url, destination, index + 1, urls.length, enableResume, {

--- a/lib/downloadPipeline.ts
+++ b/lib/downloadPipeline.ts
@@ -742,6 +742,11 @@ async function download(urls: string[], destination: string, options: DownloadOp
     // Create download promises for all URLs
     const downloadPromises = urls.map(async(url: string, index: number) => {
         try {
+            if ((options as any).session?.isCancelled()) {
+                const err = Object.assign(new Error('Download cancelled'), { code: 'CANCELLED' });
+                (options as any).session.failDownload(url, err);
+                return { url, error: err.message, success: false };
+            }
             const downloadResult = await concurrencyLimiter.execute(
                 downloadFile,
                 url,

--- a/lib/mcp/server.js
+++ b/lib/mcp/server.js
@@ -14,11 +14,6 @@
  *   batch_download    — download multiple URLs concurrently
  *   get_jobs          — list all active n-get sessions on this machine
  *   get_capabilities  — return n-get's capabilities document
- *   cancel_session    — cancel an active download session
- *   get_session       — query a specific session's current state
- *   set_profile       — apply a named config profile process-wide
- *   get_history       — return recent download history
- *   get_instructions  — return AGENTS.md contents
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.createServer = createServer;
@@ -38,7 +33,9 @@ const downloadPipeline = require('../downloadPipeline');
 const ConfigManager = require('../config/ConfigManager');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const HistoryManager = require('../services/HistoryManager');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const fs = require('node:fs');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const path = require('node:path');
 const DownloadSession_js_1 = require("../core/DownloadSession.js");
 // ─── Factory — exported for testing ──────────────────────────────────────────
@@ -53,7 +50,7 @@ function createServer() {
     const configManager = new ConfigManager({
         environment: 'development',
         enableHotReload: false,
-        logger: { info: () => {}, debug: () => {}, warn: () => {}, error: () => {} },
+        logger: { info: () => { }, debug: () => { }, warn: () => { }, error: () => { } },
     });
     // HistoryManager instance
     const historyManager = new HistoryManager();
@@ -153,8 +150,8 @@ function createServer() {
     // ── get_jobs ──────────────────────────────────────────────────────────────
     server.tool('get_jobs', 'List all active n-get download sessions on this machine. Any agent can call this to observe downloads started by other agents.', {}, () => {
         (0, DownloadSession_js_1.pruneDeadSessions)();
-        const activeSessions = (0, DownloadSession_js_1.readActiveSessions)();
-        const summary = activeSessions.map(s => {
+        const sessions = (0, DownloadSession_js_1.readActiveSessions)();
+        const summary = sessions.map(s => {
             const downloads = Object.values(s.downloads ?? {});
             return {
                 sessionId: s.sessionId,
@@ -170,7 +167,7 @@ function createServer() {
         return {
             content: [{
                     type: 'text',
-                    text: JSON.stringify({ count: activeSessions.length, sessions: summary }),
+                    text: JSON.stringify({ count: sessions.length, sessions: summary }),
                 }],
         };
     });
@@ -201,7 +198,7 @@ function createServer() {
         }
         // Check if it's a session from another process
         const activeSessions = (0, DownloadSession_js_1.readActiveSessions)();
-        const external = activeSessions.find(s => s.sessionId === sessionId);
+        const external = activeSessions.find((s) => s.sessionId === sessionId);
         if (external) {
             return {
                 isError: true,
@@ -241,7 +238,7 @@ function createServer() {
             };
         }
         const activeSessions = (0, DownloadSession_js_1.readActiveSessions)();
-        const external = activeSessions.find(s => s.sessionId === sessionId);
+        const external = activeSessions.find((s) => s.sessionId === sessionId);
         if (external) {
             return {
                 content: [{
@@ -297,9 +294,12 @@ function createServer() {
         try {
             const dest = destination ?? process.cwd();
             const opts = {};
-            if (limit)  opts.limit  = limit;
-            if (status) opts.status = status;
-            if (since)  opts.since  = new Date(since);
+            if (limit)
+                opts.limit = limit;
+            if (status)
+                opts.status = status;
+            if (since)
+                opts.since = new Date(since);
             const raw = await historyManager.getHistory(dest, opts);
             const entries = raw.map((e) => ({
                 timestamp: e.timestamp,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n-get",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "homepage": "https://bingeboy.github.io/n-get/",
   "description": "Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.",
   "repository": {


### PR DESCRIPTION
Patch to get the accurate README onto npm and clear 6 Dependabot alerts. Also fixes a silent regression: the isCancelled() guard in the download pipeline was written only to the compiled .js, so tsc would have clobbered it on the next build. Now lives in the .ts source.