### PR TITLE
release: bump 1.10.1 -> 1.10.2 — update homepage to Cloudflare Pages URL

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,21 @@
+# Release Notes - v1.10.2
+
+## Overview
+Patch. Homepage URL updated from the defunct GitHub Pages address to the live Cloudflare Pages site.
+
+## Changes
+- `package.json` `homepage`: `bingeboy.github.io/n-get` → `n-get.design-87b.workers.dev`
+- `site/index.html` added to master for Cloudflare Pages auto-deploy
+
+## Breaking Changes
+None.
+
+---
+
+**Full Changelog**: [Compare v1.10.1...v1.10.2](https://github.com/bingeboy/n-get/compare/v1.10.1...v1.10.2)
+
+---
+
 # Release Notes - v1.10.1
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n-get",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "homepage": "https://n-get.design-87b.workers.dev/",
   "description": "Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.",
   "repository": {


### PR DESCRIPTION
URL updated!