### PR TITLE
release: 1.11.0 — HMAC webhook signing + A2A 0.3.0 agent card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # n-get — Agent Instructions
 
-**Version:** 1.10.2 · **License:** MIT · **Node:** >= 18
+**Version:** 1.11.0 · **License:** MIT · **Node:** >= 18
 
 Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ nget https://example.com/data.zip | jq 'select(.event == "download_complete")'
 - `--webhook <url>` — POST every NDJSON event to a receiver (repeatable for multiple receivers)
 - `--webhook-header 'Name: value'` — add a custom header to all webhook POSTs (repeatable)
 - `--webhook-events <list>` — comma-separated event types to forward; defaults to all
+- `--webhook-secret <secret>` — HMAC-SHA256 sign every POST with `X-NGet-Signature: sha256=<hex>`; receivers verify with `timingSafeEqual`
+
+**Agent discovery:**
+- `--agent-card` — outputs an A2A 0.3.0 agent card (JSON) to stdout; serve at `/.well-known/agent.json` for orchestrator discovery
 
 **Standard agent correlation flags:** `--agent-id`, `--session-id`, `--request-id`, `--conversation-id`
 
@@ -105,7 +109,7 @@ n-get ships a standalone MCP server as the `nget-mcp` binary. Add it to your Cla
 }
 ```
 
-The MCP server exposes 9 tools for direct agent control:
+The MCP server exposes 10 tools for direct agent control:
 
 | Tool | What it does |
 |---|---|
@@ -118,6 +122,7 @@ The MCP server exposes 9 tools for direct agent control:
 | `set_profile` | Apply a config profile (fast/secure/bulk/careful) |
 | `get_history` | Flat download history with filtering |
 | `get_instructions` | Return AGENTS.md — the full agent guide |
+| `get_agent_card` | Return the A2A 0.3.0 agent card JSON |
 
 ## Configuration
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,41 @@
+# Release Notes - v1.11.0
+
+## Overview
+Agent security and discovery. Webhook receivers can now verify every n-get event is authentic (HMAC-SHA256 signing), and any A2A 0.3.0-compatible orchestrator can discover and invoke n-get from a standard agent card.
+
+## New Features
+
+### HMAC webhook signing (`--webhook-secret`)
+- `--webhook-secret <secret>` — signs every webhook POST with `X-NGet-Signature: sha256=<hmac-hex>` using `node:crypto`. No new dependency.
+- `webhooks.secret: ''` in `config/default.yaml` for persistent config.
+- Empty/absent secret = no header added (fully backwards compatible).
+- `--capabilities` reports `webhooks.signing: 'hmac-sha256'`.
+
+Receiver verification (one `timingSafeEqual` call):
+```js
+const expected = 'sha256=' + crypto.createHmac('sha256', secret).update(rawBody).digest('hex');
+const valid = crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+```
+
+### A2A 0.3.0 agent card (`--agent-card`, `get_agent_card`)
+- `nget --agent-card` — outputs A2A 0.3.0 JSON to stdout. Serve at `/.well-known/agent.json` via Cloudflare Workers, nginx, etc.
+- `get_agent_card` MCP tool — 10th MCP tool; returns the same JSON for orchestrators running over MCP.
+- Card is generated from `CapabilitiesService` — never drifts from actual capabilities.
+- `--capabilities` gains a `discovery.a2a` subsection.
+- Skills: `download`, `batch_download`, `fetch` — map 1:1 to MCP tools.
+
+## Breaking Changes
+None. All CLI flags, NDJSON event names, library exports, and MCP tool names from 1.10.x are unchanged.
+
+## Tests
+475 passing, 0 failing (up from 449 — 26 new tests across `test/webhookSigningSpec.js` and `test/a2aCardSpec.js`).
+
+---
+
+**Full Changelog**: [Compare v1.10.2...v1.11.0](https://github.com/bingeboy/n-get/compare/v1.10.2...v1.11.0)
+
+---
+
 # Release Notes - v1.10.2
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n-get",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "homepage": "https://n-get.design-87b.workers.dev/",
   "description": "Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.",
   "repository": {

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@
     <!-- <span>·</span>
     <a href="https://github.com/bingeboy/n-get/issues">Issues</a> -->
     <span>·</span>
-    <span>v1.10.2</span>
+    <span>v1.11.0</span>
     <span>·</span>
     <span>MIT</span>
   </nav>
@@ -358,6 +358,7 @@
           <tr><td>get_history</td>       <td>Download history with status and time filters</td></tr>
           <tr><td>get_capabilities</td>  <td>Full capabilities document</td></tr>
           <tr><td>get_instructions</td>  <td>AGENTS.md — the complete agent guide</td></tr>
+          <tr><td>get_agent_card</td>    <td>A2A 0.3.0 agent card — serve at /.well-known/agent.json</td></tr>
         </tbody>
       </table>
     </div>
@@ -422,6 +423,12 @@
 <span class="dim"># SFTP</span>
 <span class="hi">nget</span> sftp://user@host/path/file.tar.gz <span class="flag">--ssh-key</span> ~/.ssh/id_ed25519
 
+<span class="dim"># signed webhooks — receiver verifies X-NGet-Signature: sha256=&lt;hex&gt;</span>
+<span class="hi">nget</span> <span class="flag">--webhook</span> https://receiver/events <span class="flag">--webhook-secret</span> mysecret https://example.com/model.bin
+
+<span class="dim"># A2A 0.3.0 agent card — serve this at /.well-known/agent.json</span>
+<span class="hi">nget</span> <span class="flag">--agent-card</span>
+
 <span class="dim"># self-discovery</span>
 <span class="hi">nget</span> <span class="flag">--capabilities</span>
 <span class="hi">nget</span> <span class="flag">--openapi-spec</span>
@@ -438,7 +445,7 @@
     <span>·</span>
     <a href="https://github.com/bingeboy/n-get/blob/master/LICENSE">MIT</a>
   </nav>
-  <span>n-get v1.10.1 · Node.js ≥ 18</span>
+  <span>n-get v1.11.0 · Node.js ≥ 18</span>
 </footer>
 
 <script>


### PR DESCRIPTION
  Two agent-facing features that make n-get a verified, discoverable agent citizen. Webhook receivers can authenticate events with HMAC-SHA256
  signatures. A2A 0.3.0 orchestrators (LangChain, AWS Bedrock AgentCore, etc.) can discover and invoke n-get from a standard
  /.well-known/agent.json card.

  Highlights:
  - --webhook-secret — signs every webhook POST with X-NGet-Signature: sha256=<hex>, no new dependency (node:crypto)
  - --agent-card — outputs A2A 0.3.0 JSON to stdout; serve at /.well-known/agent.json
  - get_agent_card — 10th MCP tool, same JSON as --agent-card
  - README and site updated with all new flags and tools
  - 475 tests passing (26 new)