### PR TITLE
feat: webhook retry/backoff + A2A docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,27 @@ All active sessions are visible via `nget jobs` (NDJSON) or `nget jobs --human` 
 
 Run `nget --help` for the full flag reference.
 
+## A2A discovery
+
+n-get publishes an [A2A 0.3.0](https://a2aprotocol.ai) agent card — the standard that lets AI orchestrators (LangChain, AWS Bedrock AgentCore, Spring AI, etc.) discover and invoke agents automatically.
+
+```bash
+# output the agent card JSON
+nget --agent-card
+
+# serve it where orchestrators expect it
+nget --agent-card > /var/www/.well-known/agent.json
+```
+
+Or fetch it over MCP without leaving your agent loop:
+
+```javascript
+// MCP tool
+get_agent_card()  // returns A2A 0.3.0 JSON
+```
+
+The card is generated live from `--capabilities` — it never drifts from what n-get actually supports. Skills exposed: `download`, `batch_download`, `fetch`.
+
 ## MCP server
 
 n-get ships a standalone MCP server as the `nget-mcp` binary. Add it to your Claude Desktop config:

--- a/lib/core/EventSink.js
+++ b/lib/core/EventSink.js
@@ -45,6 +45,10 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.EventSink = exports.EVENT = void 0;
 const crypto = __importStar(require("node:crypto"));
+const { setTimeout: sleep } = require("node:timers/promises");
+// ─── Webhook retry constants ──────────────────────────────────────────────────
+const MAX_ATTEMPTS = 3;
+const BACKOFF_MS = [0, 500, 1000];
 exports.EVENT = {
     SESSION_START: 'session_start',
     SESSION_END: 'session_end',
@@ -117,23 +121,48 @@ class EventSink {
                 const sig = 'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex');
                 sigHeaders['X-NGet-Signature'] = sig;
             }
-            const controller = new AbortController();
-            const timer = setTimeout(() => controller.abort(), 2000);
-            const p = fetch(wh.url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...wh.headers,
-                    ...sigHeaders,
-                },
-                body,
-                signal: controller.signal,
-            })
-                .then(() => clearTimeout(timer))
-                .catch((err) => {
-                clearTimeout(timer);
-                process.stderr.write(`[nget] webhook POST to ${wh.url} failed: ${err.message}\n`);
-            });
+            const headers = {
+                'Content-Type': 'application/json',
+                ...wh.headers,
+                ...sigHeaders,
+            };
+            const p = (async () => {
+                for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+                    if (BACKOFF_MS[attempt] > 0) {
+                        await sleep(BACKOFF_MS[attempt]);
+                    }
+                    const controller = new AbortController();
+                    const timer = setTimeout(() => controller.abort(), 2000);
+                    try {
+                        const res = await fetch(wh.url, {
+                            method: 'POST',
+                            headers,
+                            body,
+                            signal: controller.signal,
+                        });
+                        clearTimeout(timer);
+                        if (res.status >= 400 && res.status < 500) {
+                            // 4xx — client error, do not retry
+                            process.stderr.write(`[nget] webhook POST to ${wh.url} failed (${res.status}): not retrying\n`);
+                            return;
+                        }
+                        if (res.status >= 500) {
+                            // 5xx — server error, retry unless last attempt
+                            if (attempt < MAX_ATTEMPTS - 1) { continue; }
+                            process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${MAX_ATTEMPTS} attempts: HTTP ${res.status}\n`);
+                            return;
+                        }
+                        // 1xx/2xx/3xx — success or redirect, done
+                        return;
+                    } catch (err) {
+                        clearTimeout(timer);
+                        // Network error — retry unless last attempt
+                        if (attempt < MAX_ATTEMPTS - 1) { continue; }
+                        const message = err instanceof Error ? err.message : String(err);
+                        process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${MAX_ATTEMPTS} attempts: ${message}\n`);
+                    }
+                }
+            })();
             this._inflight.push(p);
         }
     }

--- a/lib/core/EventSink.ts
+++ b/lib/core/EventSink.ts
@@ -10,6 +10,7 @@
  */
 
 import * as crypto from 'node:crypto';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 import type {
     NgetEventType,
@@ -22,6 +23,10 @@ import type {
 // UIManager is still .js — typed loosely until it migrates
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UIManager = any;
+
+// ─── Webhook retry constants ──────────────────────────────────────────────────
+const MAX_ATTEMPTS = 3;
+const BACKOFF_MS = [0, 500, 1000];
 
 export const EVENT: Record<string, NgetEventType> = {
     SESSION_START:      'session_start',
@@ -117,23 +122,50 @@ export class EventSink {
                 sigHeaders['X-NGet-Signature'] = sig;
             }
 
-            const controller = new AbortController();
-            const timer = setTimeout(() => controller.abort(), 2000);
-            const p = fetch(wh.url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    ...wh.headers,
-                    ...sigHeaders,
-                },
-                body,
-                signal: controller.signal,
-            })
-                .then(() => clearTimeout(timer))
-                .catch((err: Error) => {
-                    clearTimeout(timer);
-                    process.stderr.write(`[nget] webhook POST to ${wh.url} failed: ${err.message}\n`);
-                });
+            const headers = {
+                'Content-Type': 'application/json',
+                ...wh.headers,
+                ...sigHeaders,
+            };
+
+            const p = (async () => {
+                for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+                    if (BACKOFF_MS[attempt] > 0) {
+                        await sleep(BACKOFF_MS[attempt]);
+                    }
+                    const controller = new AbortController();
+                    const timer = setTimeout(() => controller.abort(), 2000);
+                    try {
+                        const res = await fetch(wh.url, {
+                            method: 'POST',
+                            headers,
+                            body,
+                            signal: controller.signal,
+                        });
+                        clearTimeout(timer);
+                        if (res.status >= 400 && res.status < 500) {
+                            // 4xx — client error, do not retry
+                            process.stderr.write(`[nget] webhook POST to ${wh.url} failed (${res.status}): not retrying\n`);
+                            return;
+                        }
+                        if (res.status >= 500) {
+                            // 5xx — server error, retry unless last attempt
+                            if (attempt < MAX_ATTEMPTS - 1) { continue; }
+                            process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${MAX_ATTEMPTS} attempts: HTTP ${res.status}\n`);
+                            return;
+                        }
+                        // 1xx/2xx/3xx — success or redirect, done
+                        return;
+                    } catch (err: unknown) {
+                        clearTimeout(timer);
+                        // Network error — retry unless last attempt
+                        if (attempt < MAX_ATTEMPTS - 1) { continue; }
+                        const message = err instanceof Error ? err.message : String(err);
+                        process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${MAX_ATTEMPTS} attempts: ${message}\n`);
+                    }
+                }
+            })();
+
             this._inflight.push(p);
         }
     }

--- a/site/index.html
+++ b/site/index.html
@@ -364,6 +364,20 @@
     </div>
   </section>
 
+  <section id="a2a" aria-labelledby="a2a-heading">
+    <h2 id="a2a-heading">Agent discovery</h2>
+    <h3>A2A 0.3.0</h3>
+    <p>Publish a standard agent card and any A2A-compatible orchestrator — LangChain, AWS Bedrock AgentCore, Spring AI — can discover and invoke n-get automatically. No custom integration code.</p>
+
+    <pre><code><span class="dim"># output the card</span>
+<span class="hi">nget</span> <span class="flag">--agent-card</span>
+
+<span class="dim"># serve it where orchestrators look</span>
+<span class="hi">nget</span> <span class="flag">--agent-card</span> > /var/www/.well-known/agent.json</code></pre>
+
+    <p>The card is generated live from <code>--capabilities</code> — it never drifts from what n-get actually supports. Also available as the <code>get_agent_card</code> MCP tool for agents that don't leave the MCP loop.</p>
+  </section>
+
   <section id="events" aria-labelledby="events-heading">
     <h2 id="events-heading">Observation</h2>
     <h3>NDJSON events &amp; webhooks</h3>

--- a/test/webhookRetrySpec.js
+++ b/test/webhookRetrySpec.js
@@ -1,0 +1,164 @@
+'use strict';
+/**
+ * @fileoverview Unit tests for webhook exponential-backoff retry in EventSink.
+ *
+ * Uses vi.stubGlobal('fetch', ...) for network-error tests and a real
+ * node:http server for the happy-path and HTTP-status-code tests.
+ */
+
+const http = require('node:http');
+const { EventSink } = require('../lib/core/EventSink');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function captureStream(stream) {
+    const state = { output: '' };
+    const orig = stream.write.bind(stream);
+    stream.write = function (chunk) {
+        state.output += chunk;
+        return true;
+    };
+    state.restore = function () {
+        stream.write = orig;
+    };
+    return state;
+}
+
+/**
+ * Spin up a local HTTP server that responds with the statuses in `statusSeq`
+ * in order, then 200 for any additional requests.
+ * Returns { port, callCount, close }.
+ */
+async function startStatusServer(statusSeq) {
+    let callCount = 0;
+    const server = http.createServer((req, res) => {
+        let body = '';
+        req.on('data', c => { body += c; });
+        req.on('end', () => {
+            const status = statusSeq[callCount] !== undefined ? statusSeq[callCount] : 200;
+            callCount++;
+            res.writeHead(status);
+            res.end();
+        });
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    return {
+        port,
+        get callCount() { return callCount; },
+        close: () => new Promise(resolve => server.close(resolve)),
+    };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('webhook exponential-backoff retry', () => {
+
+    // ── 1. Retries on 500 ────────────────────────────────────────────────────
+
+    it('retries on 500: makes 3 total attempts when server returns 500 twice then 200', async () => {
+        const srv = await startStatusServer([500, 500, 200]);
+        const stdout = captureStream(process.stdout);
+        const stderr = captureStream(process.stderr);
+
+        try {
+            const emitter = new EventSink({
+                sessionId: 'retry-500-test',
+                webhooks: [{ url: `http://127.0.0.1:${srv.port}/hook` }],
+            });
+            emitter.emit('info', { message: 'retry-test' });
+            await emitter.flush();
+        } finally {
+            stdout.restore();
+            stderr.restore();
+        }
+
+        await srv.close();
+
+        expect(srv.callCount).to.equal(3);
+        // No final failure message since the last attempt succeeded
+        expect(stderr.output).to.equal('');
+    });
+
+    // ── 2. No retry on 4xx ───────────────────────────────────────────────────
+
+    it('does not retry on 4xx: makes exactly 1 attempt when server returns 400', async () => {
+        const srv = await startStatusServer([400]);
+        const stdout = captureStream(process.stdout);
+        const stderr = captureStream(process.stderr);
+
+        try {
+            const emitter = new EventSink({
+                sessionId: 'no-retry-400-test',
+                webhooks: [{ url: `http://127.0.0.1:${srv.port}/hook` }],
+            });
+            emitter.emit('info', { message: 'should-not-retry' });
+            await emitter.flush();
+        } finally {
+            stdout.restore();
+            stderr.restore();
+        }
+
+        await srv.close();
+
+        expect(srv.callCount).to.equal(1);
+        expect(stderr.output).to.include('not retrying');
+    });
+
+    // ── 3. Network error retries ─────────────────────────────────────────────
+
+    it('network error: logs "failed after 3 attempts" when all attempts throw', async () => {
+        let fetchCallCount = 0;
+
+        // Stub global fetch to always throw a network error
+        vi.stubGlobal('fetch', async () => {
+            fetchCallCount++;
+            throw new Error('ECONNREFUSED');
+        });
+
+        const stdout = captureStream(process.stdout);
+        const stderr = captureStream(process.stderr);
+
+        try {
+            const emitter = new EventSink({
+                sessionId: 'network-error-test',
+                webhooks: [{ url: 'http://127.0.0.1:19999/hook' }],
+            });
+            emitter.emit('info', { message: 'network-fail' });
+            await emitter.flush();
+        } finally {
+            stdout.restore();
+            stderr.restore();
+            vi.unstubAllGlobals();
+        }
+
+        expect(fetchCallCount).to.equal(3);
+        expect(stderr.output).to.include('failed after 3 attempts');
+    });
+
+    // ── 4. Success on first try ──────────────────────────────────────────────
+
+    it('success on first try: makes exactly 1 call and logs nothing on 200', async () => {
+        const srv = await startStatusServer([200]);
+        const stdout = captureStream(process.stdout);
+        const stderr = captureStream(process.stderr);
+
+        try {
+            const emitter = new EventSink({
+                sessionId: 'success-first-test',
+                webhooks: [{ url: `http://127.0.0.1:${srv.port}/hook` }],
+            });
+            emitter.emit('info', { message: 'all-good' });
+            await emitter.flush();
+        } finally {
+            stdout.restore();
+            stderr.restore();
+        }
+
+        await srv.close();
+
+        expect(srv.callCount).to.equal(1);
+        expect(stderr.output).to.equal('');
+    });
+
+});


### PR DESCRIPTION
  Summary:
  Webhook delivery is now reliable — a temporarily unavailable receiver gets 3 attempts with exponential backoff before n-get gives up. A2A
  discovery also gets its own prominent section in the README and site (it shipped in 1.11.0 but deserved better docs).

  Highlights:
  - Webhook POSTs retry up to 3 times: 0ms → 500ms → 1000ms backoff
  - 5xx and network errors: retried silently; final failure logs to stderr
  - 4xx: no retry (client error, won't recover)
  - Per-attempt 2s timeout — flush() behavior unchanged
  - MAX_ATTEMPTS and BACKOFF_MS as module-level constants in EventSink
  - README: new ## A2A discovery section with card output + serve example
  - Site: new A2A section between MCP and events

  Breaking changes: None.

  Tests: 479 passing, 0 failing (4 new in test/webhookRetrySpec.js).