### PR TITLE
release: 1.12.0 — webhook retry/backoff + A2A docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # n-get — Agent Instructions
 
-**Version:** 1.11.0 · **License:** MIT · **Node:** >= 18
+**Version:** 1.12.0 · **License:** MIT · **Node:** >= 18
 
 Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,34 @@
+# Release Notes - v1.12.0
+
+## Overview
+Reliable webhook delivery and better docs for the agent-discovery story. Webhook receivers that are temporarily unavailable now get retried automatically. A2A 0.3.0 discovery gets its own section in the README and site.
+
+## New Features
+
+### Webhook retry with exponential backoff
+- 3 attempts total per webhook POST: immediate → 500 ms → 1000 ms
+- Retries on: network errors, HTTP 5xx
+- No retry on: HTTP 4xx (client error, won't recover)
+- Intermediate failures are silent; only final failure logs to stderr
+- Each attempt gets a fresh 2s timeout — `flush()` behavior unchanged
+- Constants (`MAX_ATTEMPTS`, `BACKOFF_MS`) are module-level in `EventSink` — configurable retry via `config/default.yaml` is tracked for a future release
+
+## Improvements
+- README: new `## A2A discovery` section explaining the agent card, how to serve it, and the `get_agent_card` MCP tool
+- Site: dedicated A2A section between MCP tools and events
+
+## Breaking Changes
+None.
+
+## Tests
+479 passing, 0 failing (4 new in `test/webhookRetrySpec.js`).
+
+---
+
+**Full Changelog**: [Compare v1.11.0...v1.12.0](https://github.com/bingeboy/n-get/compare/v1.11.0...v1.12.0)
+
+---
+
 # Release Notes - v1.11.0
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n-get",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "homepage": "https://n-get.design-87b.workers.dev/",
   "description": "Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.",
   "repository": {

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@
     <!-- <span>·</span>
     <a href="https://github.com/bingeboy/n-get/issues">Issues</a> -->
     <span>·</span>
-    <span>v1.11.0</span>
+    <span>v1.12.0</span>
     <span>·</span>
     <span>MIT</span>
   </nav>
@@ -459,7 +459,7 @@
     <span>·</span>
     <a href="https://github.com/bingeboy/n-get/blob/master/LICENSE">MIT</a>
   </nav>
-  <span>n-get v1.11.0 · Node.js ≥ 18</span>
+  <span>n-get v1.12.0 · Node.js ≥ 18</span>
 </footer>
 
 <script>


### PR DESCRIPTION
  Title: release: 1.12.0 — webhook retry/backoff + A2A docs

  Summary:
  Webhooks are now reliable — receivers that go down get retried automatically. A2A discovery finally gets the docs prominence it deserves.

  Highlights:
  - Webhook retry: 3 attempts, 500ms/1000ms backoff, silent on intermediate failures, retries 5xx+network, stops on 4xx
  - README: dedicated ## A2A discovery section
  - Site: A2A section with card output + serve instructions

  Breaking changes: None.

  Tests: 479 passing (4 new).