### PR TITLE
release: 1.13.0 — full TypeScript, drop legacy crawl, A2A first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # n-get — Agent Instructions
 
-**Version:** 1.12.0 · **License:** MIT · **Node:** >= 18
+**Version:** 1.13.0 · **License:** MIT · **Node:** >= 18
 
 Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,32 @@
+# Release Notes - v1.13.0
+
+## Overview
+Full TypeScript migration complete. Dropped legacy recursive web crawling — n-get is now purely agentic. A2A discovery leads the docs.
+
+## Changes
+
+### TypeScript migration complete
+All 14 remaining JS-only files migrated to TypeScript. The entire `lib/` directory is now TS-sourced. No more `.js`-only modules.
+
+### Dropped: recursive web crawling
+`lib/recursiveCrawler` + `lib/recursiveDownloader` deleted (~1,000 lines). Removed CLI flags: `--recursive` / `-R`, `--level`, `--no-parent` / `-np`, `--accept`, `--reject`. Agents receive explicit URLs from the LLM — HTML crawling is a legacy wget workflow with no place in an agentic tool.
+
+### Docs
+- A2A 0.3.0 discovery now leads both the README and site (above MCP)
+- `.gitignore` updated to exclude stray download artifacts
+
+## Breaking Changes
+`--recursive` / `-R` removed. No migration path — use explicit URL lists instead.
+
+## Tests
+479 passing, 0 failing — unchanged.
+
+---
+
+**Full Changelog**: [Compare v1.12.0...v1.13.0](https://github.com/bingeboy/n-get/compare/v1.12.0...v1.13.0)
+
+---
+
 # Release Notes - v1.12.0
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n-get",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "homepage": "https://n-get.design-87b.workers.dev/",
   "description": "Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.",
   "repository": {

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@
     <!-- <span>·</span>
     <a href="https://github.com/bingeboy/n-get/issues">Issues</a> -->
     <span>·</span>
-    <span>v1.12.0</span>
+    <span>v1.13.0</span>
     <span>·</span>
     <span>MIT</span>
   </nav>
@@ -459,7 +459,7 @@
     <span>·</span>
     <a href="https://github.com/bingeboy/n-get/blob/master/LICENSE">MIT</a>
   </nav>
-  <span>n-get v1.12.0 · Node.js ≥ 18</span>
+  <span>n-get v1.13.0 · Node.js ≥ 18</span>
 </footer>
 
 <script>


### PR DESCRIPTION
  Summary:
  The codebase is now 100% TypeScript. Dropped the legacy recursive web crawler — n-get is fully agentic. A2A discovery leads the docs on both
  README and site.

  Highlights:
  - All 14 remaining JS-only lib/ files migrated to TypeScript
  - recursiveCrawler + recursiveDownloader deleted (~1,000 lines)
  - --recursive, --level, --no-parent flags removed
  - A2A 0.3.0 section now leads README and site (above MCP)

  Breaking changes: --recursive / -R removed. Agents use explicit URLs — no migration path needed.

  Tests: 479 passing, 0 failing.