### PR TITLE
refactor: TypeScript any cleanup + A2A/MCP headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 </div>
 
-Observable downloads for AI agents. n-get streams NDJSON events for every fetch, exposes itself via `--capabilities` and `--openapi-spec`, surfaces every active session across processes through `nget jobs`, and ships an MCP server (`nget-mcp`) for direct integration with Claude and other MCP-compatible assistants. HTTP/HTTPS and SFTP, with resume.
+**A2A 0.3.0 · MCP · NDJSON · Webhooks**
+
+The download layer for modern agent stacks. n-get speaks A2A and MCP natively — any orchestrator that understands either protocol can discover and invoke it without glue code. Every transfer emits a structured event stream agents can parse, forward, and act on in real time. HTTP/HTTPS and SFTP, with resume and checksum verification.
 
 ## Install
 

--- a/lib/cli/configCommands.js
+++ b/lib/cli/configCommands.js
@@ -39,13 +39,9 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 const fs = __importStar(require("node:fs"));
 const path = __importStar(require("node:path"));
-// These modules are .js — typed loosely
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ConfigManager = require('../config/ConfigManager');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const OutputFormatterService = require('../services/OutputFormatterService');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ui = require('../ui');
+const ConfigManager = require("../config/ConfigManager");
+const OutputFormatterService = require("../services/OutputFormatterService");
+const ui = require("../ui");
 /**
  * CLI Configuration Command Handler
  * Provides commands for viewing, setting, and managing configuration
@@ -95,19 +91,23 @@ class ConfigCommands {
                     console.error(`${ui.emojis.error} Section '${section}' not found`);
                     process.exit(1);
                 }
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const cm = configManager;
                 configData = {
                     section: section,
                     data: sectionData,
-                    environment: configManager.options.environment,
-                    activeProfile: configManager.activeProfile || 'none'
+                    environment: cm.options.environment,
+                    activeProfile: cm.activeProfile || 'none'
                 };
             }
             else {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const cm = configManager;
                 // Show all configuration
                 configData = {
-                    environment: configManager.options.environment,
-                    activeProfile: configManager.activeProfile || 'none',
-                    configDirectory: configManager.options.configDir,
+                    environment: cm.options.environment,
+                    activeProfile: cm.activeProfile || 'none',
+                    configDirectory: cm.options.configDir,
                     configuration: config
                 };
             }
@@ -222,14 +222,15 @@ class ConfigCommands {
                 return;
             }
             profileNames.forEach(name => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const profile = profiles[name];
-                const activeIndicator = profile.active ? ' ⭐ (active)' : '';
+                const activeIndicator = profile['active'] ? ' ⭐ (active)' : '';
                 console.log(`${ui.emojis.gear} ${name}${activeIndicator}`);
-                console.log(`  Description: ${profile.description}`);
-                console.log(`  Settings: ${Object.keys(profile.config || {}).length} configuration overrides`);
+                console.log(`  Description: ${profile['description']}`);
+                console.log(`  Settings: ${Object.keys(profile['config'] || {}).length} configuration overrides`);
                 if (args.includes('--verbose') || args.includes('-v')) {
                     console.log('  Configuration:');
-                    console.log(JSON.stringify(profile.config, null, 4).replace(/^/gm, '    '));
+                    console.log(JSON.stringify(profile['config'], null, 4).replace(/^/gm, '    '));
                 }
                 console.log('');
             });
@@ -265,9 +266,11 @@ class ConfigCommands {
             await configManager.applyProfile(profileName);
             if (!cliOptions.quiet) {
                 console.log(`${ui.emojis.success} Applied profile '${profileName}'`);
-                console.log(`${ui.emojis.info} Description: ${availableProfiles[profileName].description}`);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const profileData = availableProfiles[profileName];
+                console.log(`${ui.emojis.info} Description: ${profileData['description']}`);
                 console.log(`\n${ui.emojis.gear} Profile configuration applied:`);
-                const config = availableProfiles[profileName].config;
+                const config = profileData['config'];
                 Object.keys(config).forEach(section => {
                     console.log(`  ${section}:`);
                     if (typeof config[section] === 'object') {
@@ -299,10 +302,14 @@ class ConfigCommands {
         try {
             // Validation happens automatically during initialization
             const config = configManager.getConfig();
+            // getMetrics() returns Record<string,unknown> — cast for display-only access
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const metrics = configManager.getMetrics();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const cm = configManager;
             console.log(`${ui.emojis.success} Configuration is valid`);
-            console.log(`${ui.emojis.info} Environment: ${configManager.options.environment}`);
-            console.log(`${ui.emojis.info} Active Profile: ${configManager.activeProfile || 'none'}`);
+            console.log(`${ui.emojis.info} Environment: ${cm.options.environment}`);
+            console.log(`${ui.emojis.info} Active Profile: ${cm.activeProfile || 'none'}`);
             console.log(`${ui.emojis.info} Configuration Sections: ${metrics.configSections.length}`);
             console.log(`${ui.emojis.info} Available Profiles: ${metrics.profileCount}`);
             console.log(`${ui.emojis.info} Validation Count: ${metrics.validationCount}`);
@@ -341,22 +348,26 @@ class ConfigCommands {
         }
         try {
             const configManager = this.initializeConfigManager(cliOptions);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const cm = configManager;
+            // getMetrics() returns Record<string,unknown> — cast for display-only access
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const metrics = configManager.getMetrics();
             const config = configManager.getConfig();
             // Basic information
-            console.log(`${ui.emojis.info} Environment: ${configManager.options.environment}`);
-            console.log(`${ui.emojis.info} Config Directory: ${configManager.options.configDir}`);
-            console.log(`${ui.emojis.info} Hot Reload: ${configManager.options.enableHotReload ? 'enabled' : 'disabled'}`);
+            console.log(`${ui.emojis.info} Environment: ${cm.options.environment}`);
+            console.log(`${ui.emojis.info} Config Directory: ${cm.options.configDir}`);
+            console.log(`${ui.emojis.info} Hot Reload: ${cm.options.enableHotReload ? 'enabled' : 'disabled'}`);
             console.log(`${ui.emojis.info} Load Time: ${metrics.loadTime || 'unknown'}`);
             // File existence check
             console.log(`\n${ui.emojis.folder} Configuration Files:`);
             const configFiles = [
                 'default.yaml',
-                `${configManager.options.environment}.yaml`,
+                `${cm.options.environment}.yaml`,
                 'local.yaml',
             ];
             configFiles.forEach(filename => {
-                const filePath = path.join(configManager.options.configDir, filename);
+                const filePath = path.join(cm.options.configDir, filename);
                 const exists = fs.existsSync(filePath);
                 const status = exists ? ui.emojis.success : ui.emojis.warning;
                 const message = exists ? 'Found' : 'Not found';
@@ -387,7 +398,7 @@ class ConfigCommands {
             }
             // Profile information
             console.log(`\n${ui.emojis.rocket} Profile Status:`);
-            console.log(`  Active Profile: ${configManager.activeProfile || 'none'}`);
+            console.log(`  Active Profile: ${cm.activeProfile || 'none'}`);
             console.log(`  Available Profiles: ${metrics.profileCount}`);
             console.log(`  Profile Switches: ${metrics.profileSwitches}`);
             // Metrics and statistics

--- a/lib/cli/configCommands.ts
+++ b/lib/cli/configCommands.ts
@@ -7,24 +7,20 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-// These modules are .js — typed loosely
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ConfigManager = require('../config/ConfigManager');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const OutputFormatterService = require('../services/OutputFormatterService');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ui: any = require('../ui');
+import ConfigManager = require('../config/ConfigManager');
+import OutputFormatterService = require('../services/OutputFormatterService');
+import ui = require('../ui');
 
 /**
  * CLI Configuration Command Handler
  * Provides commands for viewing, setting, and managing configuration
  */
 class ConfigCommands {
-    options: any;
-    configManager: any;
-    outputFormatter: any;
+    options: Record<string, unknown>;
+    configManager: InstanceType<typeof ConfigManager> | null;
+    outputFormatter: InstanceType<typeof OutputFormatterService>;
 
-    constructor(options: any = {}) {
+    constructor(options: Record<string, unknown> = {}) {
         this.options = options;
         this.configManager = null;
         this.outputFormatter = new OutputFormatterService();
@@ -33,10 +29,10 @@ class ConfigCommands {
     /**
      * Initialize ConfigManager for commands
      */
-    initializeConfigManager(cliOptions: any = {}): any {
+    initializeConfigManager(cliOptions: Record<string, unknown> = {}): InstanceType<typeof ConfigManager> {
         if (!this.configManager) {
             const configOptions = {
-                environment: cliOptions['config-environment'] || process.env.NODE_ENV || 'development',
+                environment: (cliOptions['config-environment'] as string | undefined) || process.env.NODE_ENV || 'development',
                 enableHotReload: false, // Disable for CLI commands
                 logger: cliOptions.quiet ? {
                     info: () => {},
@@ -61,7 +57,7 @@ class ConfigCommands {
         try {
             const config = configManager.getConfig();
 
-            let configData: any;
+            let configData: Record<string, unknown>;
             if (section) {
                 // Show specific section
                 const sectionData = configManager.get(section);
@@ -69,18 +65,22 @@ class ConfigCommands {
                     console.error(`${ui.emojis.error} Section '${section}' not found`);
                     process.exit(1);
                 }
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const cm = configManager as any;
                 configData = {
                     section: section,
                     data: sectionData,
-                    environment: configManager.options.environment,
-                    activeProfile: configManager.activeProfile || 'none'
+                    environment: cm.options.environment,
+                    activeProfile: cm.activeProfile || 'none'
                 };
             } else {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const cm = configManager as any;
                 // Show all configuration
                 configData = {
-                    environment: configManager.options.environment,
-                    activeProfile: configManager.activeProfile || 'none',
-                    configDirectory: configManager.options.configDir,
+                    environment: cm.options.environment,
+                    activeProfile: cm.activeProfile || 'none',
+                    configDirectory: cm.options.configDir,
                     configuration: config
                 };
             }
@@ -181,7 +181,7 @@ class ConfigCommands {
         }
 
         try {
-            const profiles: any = configManager.getAvailableProfiles();
+            const profiles: Record<string, unknown> = configManager.getAvailableProfiles();
             const profileNames = Object.keys(profiles);
 
             if (profileNames.length === 0) {
@@ -196,15 +196,16 @@ class ConfigCommands {
             }
 
             profileNames.forEach(name => {
-                const profile = profiles[name];
-                const activeIndicator = profile.active ? ' ⭐ (active)' : '';
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const profile = profiles[name] as Record<string, any>;
+                const activeIndicator = profile['active'] ? ' ⭐ (active)' : '';
                 console.log(`${ui.emojis.gear} ${name}${activeIndicator}`);
-                console.log(`  Description: ${profile.description}`);
-                console.log(`  Settings: ${Object.keys(profile.config || {}).length} configuration overrides`);
+                console.log(`  Description: ${profile['description']}`);
+                console.log(`  Settings: ${Object.keys(profile['config'] || {}).length} configuration overrides`);
 
                 if (args.includes('--verbose') || args.includes('-v')) {
                     console.log('  Configuration:');
-                    console.log(JSON.stringify(profile.config, null, 4).replace(/^/gm, '    '));
+                    console.log(JSON.stringify(profile['config'], null, 4).replace(/^/gm, '    '));
                 }
                 console.log('');
             });
@@ -234,7 +235,7 @@ class ConfigCommands {
         const profileName = args[0];
 
         try {
-            const availableProfiles: any = configManager.getAvailableProfiles();
+            const availableProfiles: Record<string, unknown> = configManager.getAvailableProfiles();
 
             if (!availableProfiles[profileName]) {
                 console.error(`${ui.emojis.error} Profile '${profileName}' not found`);
@@ -246,15 +247,17 @@ class ConfigCommands {
 
             if (!cliOptions.quiet) {
                 console.log(`${ui.emojis.success} Applied profile '${profileName}'`);
-                console.log(`${ui.emojis.info} Description: ${availableProfiles[profileName].description}`);
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const profileData = availableProfiles[profileName] as Record<string, any>;
+                console.log(`${ui.emojis.info} Description: ${profileData['description']}`);
                 console.log(`\n${ui.emojis.gear} Profile configuration applied:`);
 
-                const config: any = availableProfiles[profileName].config;
+                const config = profileData['config'] as Record<string, unknown>;
                 Object.keys(config).forEach(section => {
                     console.log(`  ${section}:`);
                     if (typeof config[section] === 'object') {
-                        Object.keys(config[section]).forEach(key => {
-                            console.log(`    ${key}: ${JSON.stringify(config[section][key])}`);
+                        Object.keys(config[section] as Record<string, unknown>).forEach(key => {
+                            console.log(`    ${key}: ${JSON.stringify((config[section] as Record<string, unknown>)[key])}`);
                         });
                     } else {
                         console.log(`    ${JSON.stringify(config[section])}`);
@@ -282,11 +285,15 @@ class ConfigCommands {
         try {
             // Validation happens automatically during initialization
             const config = configManager.getConfig();
-            const metrics: any = configManager.getMetrics();
+            // getMetrics() returns Record<string,unknown> — cast for display-only access
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const metrics = configManager.getMetrics() as Record<string, any>;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const cm = configManager as any;
 
             console.log(`${ui.emojis.success} Configuration is valid`);
-            console.log(`${ui.emojis.info} Environment: ${configManager.options.environment}`);
-            console.log(`${ui.emojis.info} Active Profile: ${configManager.activeProfile || 'none'}`);
+            console.log(`${ui.emojis.info} Environment: ${cm.options.environment}`);
+            console.log(`${ui.emojis.info} Active Profile: ${cm.activeProfile || 'none'}`);
             console.log(`${ui.emojis.info} Configuration Sections: ${metrics.configSections.length}`);
             console.log(`${ui.emojis.info} Available Profiles: ${metrics.profileCount}`);
             console.log(`${ui.emojis.info} Validation Count: ${metrics.validationCount}`);
@@ -329,25 +336,29 @@ class ConfigCommands {
 
         try {
             const configManager = this.initializeConfigManager(cliOptions);
-            const metrics: any = configManager.getMetrics();
-            const config: any = configManager.getConfig();
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const cm = configManager as any;
+            // getMetrics() returns Record<string,unknown> — cast for display-only access
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const metrics = configManager.getMetrics() as Record<string, any>;
+            const config = configManager.getConfig();
 
             // Basic information
-            console.log(`${ui.emojis.info} Environment: ${configManager.options.environment}`);
-            console.log(`${ui.emojis.info} Config Directory: ${configManager.options.configDir}`);
-            console.log(`${ui.emojis.info} Hot Reload: ${configManager.options.enableHotReload ? 'enabled' : 'disabled'}`);
+            console.log(`${ui.emojis.info} Environment: ${cm.options.environment}`);
+            console.log(`${ui.emojis.info} Config Directory: ${cm.options.configDir}`);
+            console.log(`${ui.emojis.info} Hot Reload: ${cm.options.enableHotReload ? 'enabled' : 'disabled'}`);
             console.log(`${ui.emojis.info} Load Time: ${metrics.loadTime || 'unknown'}`);
 
             // File existence check
             console.log(`\n${ui.emojis.folder} Configuration Files:`);
             const configFiles = [
                 'default.yaml',
-                `${configManager.options.environment}.yaml`,
+                `${cm.options.environment}.yaml`,
                 'local.yaml',
             ];
 
             configFiles.forEach(filename => {
-                const filePath = path.join(configManager.options.configDir, filename);
+                const filePath = path.join(cm.options.configDir, filename);
                 const exists = fs.existsSync(filePath);
                 const status = exists ? ui.emojis.success : ui.emojis.warning;
                 const message = exists ? 'Found' : 'Not found';
@@ -380,7 +391,7 @@ class ConfigCommands {
 
             // Profile information
             console.log(`\n${ui.emojis.rocket} Profile Status:`);
-            console.log(`  Active Profile: ${configManager.activeProfile || 'none'}`);
+            console.log(`  Active Profile: ${cm.activeProfile || 'none'}`);
             console.log(`  Available Profiles: ${metrics.profileCount}`);
             console.log(`  Profile Switches: ${metrics.profileSwitches}`);
 

--- a/lib/cli/historyCommands.js
+++ b/lib/cli/historyCommands.js
@@ -39,11 +39,8 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 const path = __importStar(require("node:path"));
 const fs = __importStar(require("node:fs"));
-// These services are .js/.ts — typed loosely
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const HistoryManager = require('../services/HistoryManager');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const OutputFormatterService = require('../services/OutputFormatterService');
+const HistoryManager = require("../services/HistoryManager");
+const OutputFormatterService = require("../services/OutputFormatterService");
 /**
  * Handler for history CLI commands
  * Provides functionality to view, search, analyze, and manage download history

--- a/lib/cli/historyCommands.ts
+++ b/lib/cli/historyCommands.ts
@@ -7,19 +7,16 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
-// These services are .js/.ts — typed loosely
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const HistoryManager = require('../services/HistoryManager');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const OutputFormatterService = require('../services/OutputFormatterService');
+import HistoryManager = require('../services/HistoryManager');
+import OutputFormatterService = require('../services/OutputFormatterService');
 
 /**
  * Handler for history CLI commands
  * Provides functionality to view, search, analyze, and manage download history
  */
 class HistoryCommands {
-    historyManager: any;
-    outputFormatter: any;
+    historyManager: InstanceType<typeof HistoryManager>;
+    outputFormatter: InstanceType<typeof OutputFormatterService>;
 
     /**
      * Creates a new HistoryCommands instance
@@ -80,7 +77,7 @@ class HistoryCommands {
             until: argv.until ? new Date(argv.until) : null,
         };
 
-        const entries: any[] = await this.historyManager.getHistory(destination, options);
+        const entries = await this.historyManager.getHistory(destination, options);
 
         if (entries.length === 0) {
             console.log('No download history found.');
@@ -164,7 +161,7 @@ class HistoryCommands {
             status: argv.status,
         };
 
-        const entries: any[] = await this.historyManager.getHistory(destination, options);
+        const entries = await this.historyManager.getHistory(destination, options);
 
         if (entries.length === 0) {
             console.log(`No downloads found matching: "${searchTerm}"`);
@@ -191,7 +188,7 @@ class HistoryCommands {
      */
     async handleStatsCommand(destination: string, argv: any): Promise<void> {
         const days = argv.days ? parseInt(argv.days) : 30;
-        const stats: any = await this.historyManager.getStatistics(destination, {days});
+        const stats = await this.historyManager.getStatistics(destination, {days});
 
         console.log(`\n📈 Download Statistics (Last ${days} days):`);
         console.log('═'.repeat(50));

--- a/lib/core/DownloadSession.js
+++ b/lib/core/DownloadSession.js
@@ -48,15 +48,13 @@ const fs = __importStar(require("node:fs"));
 const path = __importStar(require("node:path"));
 const crypto = __importStar(require("node:crypto"));
 const EventSink_js_1 = require("./EventSink.js");
+const SecurityService = require("../services/SecurityService");
+const MetadataService = require("../services/MetadataService");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const NGET_VERSION = require('../../package.json').version;
-// These services are still .js — loosely typed until they migrate
+// Logger is still .js — loosely typed until it migrates
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const Logger = require('../services/Logger');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const SecurityService = require('../services/SecurityService');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const MetadataService = require('../services/MetadataService');
 exports.ACTIVE_DIR = path.join(os.homedir(), '.nget', 'active');
 // ─── DownloadSession ─────────────────────────────────────────────────────────
 class DownloadSession {
@@ -65,15 +63,13 @@ class DownloadSession {
     humanMode;
     pipeMode;
     quietMode;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     configManager;
     startTime;
     emitter;
+    // logger is still a .js module — loosely typed until it migrates
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     logger;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     securityService;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     metadataService;
     _statusFile;
     _status;
@@ -184,22 +180,26 @@ class DownloadSession {
         this._writeChain = this._writeChain.then(() => new Promise(resolve => fs.writeFile(this._statusFile, payload, () => resolve())));
     }
     _buildLogger() {
-        const cfg = this.configManager ? this.configManager.get('logging', {}) : {};
+        const cfg = this.configManager
+            ? this.configManager.get('logging', {})
+            : {};
         return new Logger({
-            level: cfg.level ?? process.env['LOG_LEVEL'] ?? 'info',
-            format: cfg.format ?? 'text',
-            outputs: this.quietMode ? [] : (cfg.outputs ?? ['console']),
-            enableColors: !this.quietMode && cfg.enableColors !== false,
+            level: cfg['level'] ?? process.env['LOG_LEVEL'] ?? 'info',
+            format: cfg['format'] ?? 'text',
+            outputs: this.quietMode ? [] : (cfg['outputs'] ?? ['console']),
+            enableColors: !this.quietMode && cfg['enableColors'] !== false,
         });
     }
     _buildSecurity() {
-        const cfg = this.configManager ? this.configManager.get('security', {}) : {};
+        const cfg = this.configManager
+            ? this.configManager.get('security', {})
+            : {};
         return new SecurityService({
             config: {
                 security: {
-                    allowedProtocols: cfg.allowedProtocols ?? ['https', 'http', 'sftp'],
-                    blockPrivateNetworks: cfg.blockPrivateNetworks ?? false,
-                    blockLocalhost: cfg.blockLocalhost ?? false,
+                    allowedProtocols: cfg['allowedProtocols'] ?? ['https', 'http', 'sftp'],
+                    blockPrivateNetworks: cfg['blockPrivateNetworks'] ?? false,
+                    blockLocalhost: cfg['blockLocalhost'] ?? false,
                 },
             },
             logger: this.logger,

--- a/lib/core/DownloadSession.ts
+++ b/lib/core/DownloadSession.ts
@@ -20,17 +20,17 @@ import type {
 } from '../../types/index.js';
 
 import { EventSink } from './EventSink.js';
+import ConfigManager = require('../config/ConfigManager');
+import SecurityService = require('../services/SecurityService');
+import MetadataService = require('../services/MetadataService');
+import ui = require('../ui');
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const NGET_VERSION = require('../../package.json').version as string;
 
-// These services are still .js — loosely typed until they migrate
+// Logger is still .js — loosely typed until it migrates
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const Logger          = require('../services/Logger');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const SecurityService = require('../services/SecurityService');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const MetadataService = require('../services/MetadataService');
+const Logger = require('../services/Logger');
 
 export const ACTIVE_DIR = path.join(os.homedir(), '.nget', 'active');
 
@@ -43,10 +43,9 @@ export interface DownloadSessionOptions {
     pipeMode?:      boolean;
     quietMode?:     boolean;
     webhooks?:      WebhookConfig[];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    configManager?: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ui?:            any;
+    configManager?: InstanceType<typeof ConfigManager> | null;
+    /** The singleton UIManager instance from lib/ui.ts */
+    ui?:            typeof ui | null;
 }
 
 export interface CompletedDownload {
@@ -64,17 +63,15 @@ export class DownloadSession {
     public readonly humanMode:   boolean;
     public readonly pipeMode:    boolean;
     public readonly quietMode:   boolean;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public readonly configManager: any;
+    public readonly configManager: InstanceType<typeof ConfigManager> | null;
     public readonly startTime:   number;
 
     public readonly emitter:         EventSink;
+    // logger is still a .js module — loosely typed until it migrates
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public readonly logger:          any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public readonly securityService: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public readonly metadataService: any;
+    public readonly securityService: InstanceType<typeof SecurityService>;
+    public readonly metadataService: InstanceType<typeof MetadataService>;
 
     private readonly _statusFile: string;
     private          _status:     SessionStatus;
@@ -196,23 +193,27 @@ export class DownloadSession {
     }
 
     private _buildLogger() {
-        const cfg = this.configManager ? this.configManager.get('logging', {}) : {};
+        const cfg = this.configManager
+            ? this.configManager.get('logging', {}) as Record<string, unknown>
+            : {} as Record<string, unknown>;
         return new Logger({
-            level:        cfg.level         ?? process.env['LOG_LEVEL'] ?? 'info',
-            format:       cfg.format        ?? 'text',
-            outputs:      this.quietMode ? [] : (cfg.outputs ?? ['console']),
-            enableColors: !this.quietMode && cfg.enableColors !== false,
+            level:        cfg['level']        ?? process.env['LOG_LEVEL'] ?? 'info',
+            format:       cfg['format']       ?? 'text',
+            outputs:      this.quietMode ? [] : (cfg['outputs'] ?? ['console']),
+            enableColors: !this.quietMode && cfg['enableColors'] !== false,
         });
     }
 
     private _buildSecurity() {
-        const cfg = this.configManager ? this.configManager.get('security', {}) : {};
+        const cfg = this.configManager
+            ? this.configManager.get('security', {}) as Record<string, unknown>
+            : {} as Record<string, unknown>;
         return new SecurityService({
             config: {
                 security: {
-                    allowedProtocols:     cfg.allowedProtocols     ?? ['https', 'http', 'sftp'],
-                    blockPrivateNetworks: cfg.blockPrivateNetworks  ?? false,
-                    blockLocalhost:       cfg.blockLocalhost        ?? false,
+                    allowedProtocols:     cfg['allowedProtocols']     ?? ['https', 'http', 'sftp'],
+                    blockPrivateNetworks: cfg['blockPrivateNetworks']  ?? false,
+                    blockLocalhost:       cfg['blockLocalhost']        ?? false,
                 },
             },
             logger: this.logger,
@@ -225,7 +226,7 @@ export class DownloadSession {
             logger:                this.logger,
             config:                fullConfig,
             enableIntegrityChecks: this.configManager
-                ? this.configManager.get('security.enableIntegrityChecks', true)
+                ? (this.configManager.get('security.enableIntegrityChecks', true) as boolean)
                 : true,
             enableTimingMetrics: true,
         });

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -5,8 +5,7 @@
  * @module fetch
  */
 // Use Node.js built-in fetch (available in Node 18+)
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const ConfigManager = require('./config/ConfigManager');
+const ConfigManager = require("./config/ConfigManager");
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { getHttpAgent } = require('./downloader');
 // Initialize configuration
@@ -126,16 +125,17 @@ async function ngetFetch(url, options = {}) {
         const latencyMs = Date.now() - startTime;
         const err = error;
         // Enhance error with request details
-        const enhancedError = new Error(`Request failed: ${err.message}`);
-        enhancedError.code = err.code || 'REQUEST_FAILED';
-        enhancedError.latencyMs = latencyMs;
-        enhancedError.config = {
+        const baseError = new Error(`Request failed: ${err.message}`);
+        const enhancedError = baseError;
+        enhancedError['code'] = err.code || 'REQUEST_FAILED';
+        enhancedError['latencyMs'] = latencyMs;
+        enhancedError['config'] = {
             method: fetchOptions.method,
             url,
             headers: fetchOptions.headers,
             timeout: requestTimeout
         };
-        enhancedError.request = { url, method: fetchOptions.method };
+        enhancedError['request'] = { url, method: fetchOptions.method };
         throw enhancedError;
     }
 }

--- a/lib/fetch.ts
+++ b/lib/fetch.ts
@@ -5,13 +5,12 @@
  */
 
 // Use Node.js built-in fetch (available in Node 18+)
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const ConfigManager = require('./config/ConfigManager');
+import ConfigManager = require('./config/ConfigManager');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { getHttpAgent } = require('./downloader');
 
 // Initialize configuration
-let configManager: any;
+let configManager: InstanceType<typeof ConfigManager> | null;
 try {
     configManager = new ConfigManager({
         logger: { info: () => {}, debug: () => {}, warn: () => {}, error: console.error }
@@ -109,14 +108,14 @@ async function ngetFetch(url: string, options: FetchOptions = {}): Promise<Fetch
 
     // Get timeout from config or options
     const requestTimeout: number = timeout ||
-        (configManager ? configManager.get('http.timeout', 30000) : 30000);
+        (configManager ? (configManager.get('http.timeout', 30000) as number) : 30000);
 
     // Build fetch options
-    const fetchOptions: any = {
+    const fetchOptions: Record<string, unknown> & { headers: Record<string, string>; method: string } = {
         method: method.toUpperCase(),
         headers: {
             'User-Agent': configManager ?
-                configManager.get('http.userAgent', 'N-Get-Enterprise/2.0') :
+                (configManager.get('http.userAgent', 'N-Get-Enterprise/2.0') as string) :
                 'N-Get-Enterprise/2.0',
             ...headers
         },
@@ -166,16 +165,17 @@ async function ngetFetch(url: string, options: FetchOptions = {}): Promise<Fetch
         const latencyMs = Date.now() - startTime;
         const err = error as Error & { code?: string };
         // Enhance error with request details
-        const enhancedError: any = new Error(`Request failed: ${err.message}`);
-        enhancedError.code = err.code || 'REQUEST_FAILED';
-        enhancedError.latencyMs = latencyMs;
-        enhancedError.config = {
+        const baseError = new Error(`Request failed: ${err.message}`);
+        const enhancedError = baseError as typeof baseError & Record<string, unknown>;
+        enhancedError['code'] = err.code || 'REQUEST_FAILED';
+        enhancedError['latencyMs'] = latencyMs;
+        enhancedError['config'] = {
             method: fetchOptions.method,
             url,
             headers: fetchOptions.headers,
             timeout: requestTimeout
         };
-        enhancedError.request = { url, method: fetchOptions.method };
+        enhancedError['request'] = { url, method: fetchOptions.method };
 
         throw enhancedError;
     }

--- a/lib/sftpManager.js
+++ b/lib/sftpManager.js
@@ -37,19 +37,18 @@ var __importStar = (this && this.__importStar) || (function () {
         return result;
     };
 })();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 const fs = __importStar(require("node:fs"));
 const path = __importStar(require("node:path"));
 const node_stream_1 = require("node:stream");
-// ssh2-sftp-client has no @types package — typed as any
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const SftpClient = require('ssh2-sftp-client');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ui = require('./ui');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+const SftpClient = require("ssh2-sftp-client");
+const ui = require("./ui");
+const DownloadError_1 = __importDefault(require("./errors/DownloadError"));
+// resumeManager is a .js module without types — typed as any (no TS equivalent exists)
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any
 const resumeManager = require('./resumeManager');
-// Enterprise error handling
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const DownloadError = require('./errors/DownloadError');
 /**
  * SFTP Manager for handling SSH/SFTP downloads with authentication and connection caching
  * Supports key-based authentication, password authentication, and connection reuse
@@ -79,18 +78,18 @@ class SftpManager {
                 filename: path.basename(urlObject.pathname),
             };
             if (!connection.host) {
-                throw DownloadError.validationError('url', url, 'Invalid SFTP URL: missing hostname');
+                throw DownloadError_1.default.validationError('url', url, 'Invalid SFTP URL: missing hostname');
             }
             if (!connection.remotePath || connection.remotePath === '/') {
-                throw DownloadError.validationError('url', url, 'Invalid SFTP URL: missing file path');
+                throw DownloadError_1.default.validationError('url', url, 'Invalid SFTP URL: missing file path');
             }
             return connection;
         }
         catch (error) {
-            if (error instanceof DownloadError) {
+            if (error instanceof DownloadError_1.default) {
                 throw error;
             }
-            throw DownloadError.validationError('url', url, `Failed to parse SFTP URL: ${error.message}`);
+            throw DownloadError_1.default.validationError('url', url, `Failed to parse SFTP URL: ${error.message}`);
         }
     }
     /**
@@ -104,13 +103,13 @@ class SftpManager {
      */
     async createConnectionConfig(config, options = {}) {
         const { configManager } = options;
-        const sshConfig = configManager ? configManager.get('ssh', {}) : {};
+        const sshConfig = (configManager ? configManager.get('ssh', {}) : {});
         const connectionConfig = {
             host: config.host,
             port: config.port,
             username: config.username,
-            readyTimeout: options.timeout || sshConfig.timeout || 30000,
-            algorithms: sshConfig.algorithms || {
+            readyTimeout: options.timeout || sshConfig['timeout'] || 30000,
+            algorithms: sshConfig['algorithms'] || {
                 kex: ['ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521', 'diffie-hellman-group14-sha256'],
                 serverHostKey: ['rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa', 'ecdsa-sha2-nistp256'],
                 cipher: ['aes128-gcm', 'aes256-gcm', 'aes128-ctr', 'aes256-ctr'],
@@ -226,7 +225,8 @@ class SftpManager {
             return {
                 size: stats.size,
                 mode: stats.mode,
-                mtime: stats.mtime,
+                // @types uses modifyTime; some servers expose mtime — use whichever is present
+                mtime: stats.modifyTime,
                 isFile,
                 isDirectory,
             };
@@ -432,8 +432,8 @@ class SftpManager {
         catch (error) {
             // Convert to appropriate DownloadError if not already
             let downloadError = error;
-            if (!(error instanceof DownloadError)) {
-                downloadError = DownloadError.sftpError('download', error.message, {
+            if (!(error instanceof DownloadError_1.default)) {
+                downloadError = DownloadError_1.default.sftpError('download', error.message, {
                     url,
                     destination,
                     originalError: error,

--- a/lib/sftpManager.ts
+++ b/lib/sftpManager.ts
@@ -8,17 +8,13 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {Transform} from 'node:stream';
 
-// ssh2-sftp-client has no @types package — typed as any
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const SftpClient: any = require('ssh2-sftp-client');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const ui: any = require('./ui');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+import SftpClient = require('ssh2-sftp-client');
+import ui = require('./ui');
+import DownloadError from './errors/DownloadError';
+import ConfigManager = require('./config/ConfigManager');
+// resumeManager is a .js module without types — typed as any (no TS equivalent exists)
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any
 const resumeManager: any = require('./resumeManager');
-
-// Enterprise error handling
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const DownloadError: any = require('./errors/DownloadError');
 
 interface ParsedSftpConnection {
     host: string;
@@ -34,24 +30,24 @@ interface SshConnectionConfig {
     port: number;
     username: string;
     readyTimeout: number;
-    algorithms: any;
-    privateKey?: any;
+    algorithms: Record<string, string[]>;
+    privateKey?: Buffer;
     passphrase?: string;
     password?: string;
 }
 
 interface ResumeCheckHeaders {
-    'last-modified'?: any;
-    [key: string]: any;
+    'last-modified'?: unknown;
+    [key: string]: unknown;
 }
 
 interface DownloadOptions {
     outputToStdout?: boolean;
     stdoutMode?: boolean;
     quietMode?: boolean;
-    configManager?: any;
+    configManager?: InstanceType<typeof ConfigManager> | null;
     timeout?: number;
-    privateKey?: any;
+    privateKey?: Buffer;
     passphrase?: string;
     keyPath?: string;
     password?: string;
@@ -70,7 +66,7 @@ interface DownloadResult {
 interface FileInfo {
     size: number;
     mode: number;
-    mtime: any;
+    mtime: number;
     isFile: boolean;
     isDirectory: boolean;
 }
@@ -78,7 +74,7 @@ interface FileInfo {
 interface ResumeSupportResult {
     supportsResume: boolean;
     totalSize: number;
-    lastModified: any;
+    lastModified: number;
     isFile: boolean;
 }
 
@@ -86,7 +82,7 @@ interface DirectoryItem {
     name: string;
     size: number;
     type: string;
-    modifyTime: any;
+    modifyTime: number;
     isFile: boolean;
     isDirectory: boolean;
 }
@@ -96,7 +92,7 @@ interface DirectoryItem {
  * Supports key-based authentication, password authentication, and connection reuse
  */
 class SftpManager {
-    connections: Map<string, any>;
+    connections: Map<string, InstanceType<typeof SftpClient>>;
     defaultPort: number;
 
     constructor() {
@@ -153,14 +149,14 @@ class SftpManager {
      */
     async createConnectionConfig(config: ParsedSftpConnection, options: DownloadOptions = {}): Promise<SshConnectionConfig> {
         const {configManager} = options;
-        const sshConfig: any = configManager ? configManager.get('ssh', {}) : {};
+        const sshConfig = (configManager ? configManager.get('ssh', {}) : {}) as Record<string, unknown>;
 
         const connectionConfig: SshConnectionConfig = {
             host: config.host,
             port: config.port,
             username: config.username,
-            readyTimeout: options.timeout || sshConfig.timeout || 30000,
-            algorithms: sshConfig.algorithms || {
+            readyTimeout: options.timeout || (sshConfig['timeout'] as number | undefined) || 30000,
+            algorithms: (sshConfig['algorithms'] as Record<string, string[]> | undefined) || {
                 kex: ['ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521', 'diffie-hellman-group14-sha256'],
                 serverHostKey: ['rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa', 'ecdsa-sha2-nistp256'],
                 cipher: ['aes128-gcm', 'aes256-gcm', 'aes128-ctr', 'aes256-ctr'],
@@ -214,7 +210,7 @@ class SftpManager {
     /**
      * Get or create SFTP connection
      */
-    async getConnection(config: ParsedSftpConnection, options: DownloadOptions = {}): Promise<any> {
+    async getConnection(config: ParsedSftpConnection, options: DownloadOptions = {}): Promise<InstanceType<typeof SftpClient>> {
         const connectionKey = this.getConnectionKey(config);
 
         // Check for existing connection
@@ -251,9 +247,12 @@ class SftpManager {
     /**
      * Get remote file information
      */
-    async getFileInfo(sftp: any, remotePath: string): Promise<FileInfo> {
+    async getFileInfo(sftp: InstanceType<typeof SftpClient>, remotePath: string): Promise<FileInfo> {
+        // Some SFTP servers return Stats with function or boolean isFile/isDirectory
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        type SftpStats = SftpClient.FileStats & { isFile?: any; isDirectory?: any };
         try {
-            const stats: any = await sftp.stat(remotePath);
+            const stats = await sftp.stat(remotePath) as SftpStats;
 
             // Handle different SFTP server stat object formats
             let isFile: boolean;
@@ -281,7 +280,8 @@ class SftpManager {
             return {
                 size: stats.size,
                 mode: stats.mode,
-                mtime: stats.mtime,
+                // @types uses modifyTime; some servers expose mtime — use whichever is present
+                mtime: stats.modifyTime,
                 isFile,
                 isDirectory,
             };
@@ -297,7 +297,7 @@ class SftpManager {
     /**
      * Check if SFTP server supports resume (always true for SFTP)
      */
-    async checkResumeSupport(sftp: any, remotePath: string): Promise<ResumeSupportResult> {
+    async checkResumeSupport(sftp: InstanceType<typeof SftpClient>, remotePath: string): Promise<ResumeSupportResult> {
         try {
             const fileInfo = await this.getFileInfo(sftp, remotePath);
             return {
@@ -314,7 +314,7 @@ class SftpManager {
     /**
      * Create progress tracking transform for SFTP
      */
-    createSftpProgressTracker(progressBar: any, totalSize: number, startByte: number = 0): Transform {
+    createSftpProgressTracker(progressBar: import('cli-progress').SingleBar | null, totalSize: number, startByte: number = 0): Transform {
         let downloaded = startByte;
         let lastUpdate = Date.now();
         let chunkCount = 0;
@@ -412,7 +412,7 @@ class SftpManager {
             }
 
             // Create progress bar for large files (not in stdout mode)
-            let progressBar: any = null;
+            let progressBar: import('cli-progress').SingleBar | null = null;
             if (!quietMode && !stdoutMode && totalSize > 1024) {
                 progressBar = ui.createProgressBar(config.filename, totalSize);
                 if (isResume) {
@@ -421,7 +421,7 @@ class SftpManager {
             }
 
             // Create write stream (stdout for stdout mode, file for normal mode)
-            let writeStream: any;
+            let writeStream: NodeJS.WritableStream;
             if (outputToStdout) {
                 writeStream = process.stdout;
             } else {
@@ -548,8 +548,8 @@ class SftpManager {
             const config = this.parseSftpUrl(url);
             const sftp = await this.getConnection(config, options);
 
-            const list: any[] = await sftp.list(config.remotePath);
-            return list.map((item: any) => ({
+            const list = await sftp.list(config.remotePath);
+            return list.map((item) => ({
                 name: item.name,
                 size: item.size,
                 type: item.type,

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -39,9 +39,7 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 const path = __importStar(require("node:path"));
-// cli-progress has no @types package — typed as any
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const cliProgress = require('cli-progress');
+const cliProgress = __importStar(require("cli-progress"));
 // Colors is imported to extend String.prototype with color methods
 require('colors');
 /**

--- a/lib/ui.ts
+++ b/lib/ui.ts
@@ -7,9 +7,7 @@
 
 import * as path from 'node:path';
 
-// cli-progress has no @types package — typed as any
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const cliProgress: any = require('cli-progress');
+import * as cliProgress from 'cli-progress';
 // Colors is imported to extend String.prototype with color methods
 require('colors');
 
@@ -85,7 +83,7 @@ interface ResumableDownloadItem {
  * Handles all terminal output including progress bars, status messages, and formatted displays
  */
 class UIManager {
-    multibar: any;
+    multibar: cliProgress.MultiBar | null;
     spinners: Map<string, MockSpinner>;
     enableEmojis: boolean;
 
@@ -195,7 +193,7 @@ class UIManager {
     }
 
     // Create a progress bar for downloads
-    createProgressBar(label: string, total: number): any {
+    createProgressBar(label: string, total: number): cliProgress.SingleBar {
         this.multibar ||= new cliProgress.MultiBar({
             clearOnComplete: false,
             hideCursor: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n-get",
-  "version": "1.10.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n-get",
-      "version": "1.10.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.1",
@@ -25,7 +25,10 @@
         "nget-mcp": "lib/mcp/server.js"
       },
       "devDependencies": {
+        "@types/cli-progress": "^3.11.6",
         "@types/node": "^25.6.0",
+        "@types/node-fetch": "^2.6.13",
+        "@types/ssh2-sftp-client": "^9.0.6",
         "cross-env": "^7.0.3",
         "eslint": "^9.31.0",
         "nyc": "^15.1.0",
@@ -1187,6 +1190,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.6.tgz",
+      "integrity": "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1217,6 +1230,54 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-sftp-client": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-sftp-client/-/ssh2-sftp-client-9.0.6.tgz",
+      "integrity": "sha512-4+KvXO/V77y9VjI2op2T8+RCGI/GXQAwR0q5Qkj/EJ5YSeyKszqZP6F8i3H3txYoBqjc7sgorqyvBP3+w1EHyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^1.0.0"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.6",
@@ -1514,6 +1575,13 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1768,6 +1836,19 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1953,6 +2034,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2052,6 +2143,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2573,6 +2680,46 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -2766,6 +2913,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,10 @@
     "nget-mcp": "./lib/mcp/server.js"
   },
   "devDependencies": {
+    "@types/cli-progress": "^3.11.6",
     "@types/node": "^25.6.0",
+    "@types/node-fetch": "^2.6.13",
+    "@types/ssh2-sftp-client": "^9.0.6",
     "cross-env": "^7.0.3",
     "eslint": "^9.31.0",
     "nyc": "^15.1.0",

--- a/site/index.html
+++ b/site/index.html
@@ -311,7 +311,7 @@
 
 <header>
   <span class="logo" aria-label="n-get">𝐍̴̡͉̞̿͐͝-̸̺͙̦̄̄̽́͝𝐆̸͕̟̺̽͑̈́𝐄̸̢̦͖ͤͤ̾̀̕ᴛ̵͙̫͖ⷮ͒̈́</span>
-  <p>Observable downloads for AI agents — NDJSON event stream, MCP tools, webhook forwarding, HTTP&nbsp;+&nbsp;SFTP.</p>
+  <p>The download layer for modern agent stacks. A2A&nbsp;0.3.0&nbsp;· MCP&nbsp;· NDJSON&nbsp;· Webhooks. Any orchestrator that speaks A2A or MCP can discover and invoke it — no glue code.</p>
 
   <div class="install">
     <span class="prompt">$</span>


### PR DESCRIPTION
  Summary:
  Proper types throughout — internal classes no longer typed as any, @types packages installed for third-party deps. Headline repositioned to
  lead with A2A 0.3.0 and MCP as the story.

  Highlights:
  - ConfigManager, HistoryManager, OutputFormatterService, SecurityService, MetadataService, UIManager — all properly typed everywhere they're
  consumed
  - @types/cli-progress, @types/ssh2-sftp-client, @types/node-fetch installed
  - README + site: "The download layer for modern agent stacks. A2A 0.3.0 · MCP · NDJSON · Webhooks."

  Breaking changes: None.

  Tests: 479 passing, 0 failing.