### PR TITLE
release: 2.1.0 — A2A 1.0, fetch_http MCP tool, configurable webhook retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ nget https://example.com/data.zip | jq 'select(.event == "download_complete")'
 - `--webhook-header 'Name: value'` — add a custom header to all webhook POSTs (repeatable)
 - `--webhook-events <list>` — comma-separated event types to forward; defaults to all
 - `--webhook-secret <secret>` — HMAC-SHA256 sign every POST with `X-NGet-Signature: sha256=<hex>`; receivers verify with `timingSafeEqual`
+- Retry behaviour is configurable via `webhooks.retry.maxAttempts` and `webhooks.retry.backoffMs` in config — defaults to 3 attempts with [0, 500, 1000] ms backoff
 
 **Agent discovery:**
 - `--agent-card` — outputs an A2A 1.0 agent card (JSON) to stdout; serve at `/.well-known/agent.json` for orchestrator discovery
@@ -130,7 +131,7 @@ n-get ships a standalone MCP server as the `nget-mcp` binary. Add it to your Cla
 }
 ```
 
-The MCP server exposes 10 tools for direct agent control:
+The MCP server exposes 11 tools for direct agent control:
 
 | Tool | What it does |
 |---|---|
@@ -143,6 +144,7 @@ The MCP server exposes 10 tools for direct agent control:
 | `set_profile` | Apply a config profile (fast/secure/bulk/careful) |
 | `get_history` | Flat download history with filtering |
 | `get_instructions` | Return AGENTS.md — the full agent guide |
+| `fetch_http` | Make an HTTP API call (GET/POST/PUT/DELETE/PATCH) without leaving the MCP loop |
 | `get_agent_card` | Return the A2A 1.0 agent card JSON |
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ nget https://example.com/data.zip | jq 'select(.event == "download_complete")'
 - `--webhook-secret <secret>` — HMAC-SHA256 sign every POST with `X-NGet-Signature: sha256=<hex>`; receivers verify with `timingSafeEqual`
 
 **Agent discovery:**
-- `--agent-card` — outputs an A2A 0.3.0 agent card (JSON) to stdout; serve at `/.well-known/agent.json` for orchestrator discovery
+- `--agent-card` — outputs an A2A 1.0 agent card (JSON) to stdout; serve at `/.well-known/agent.json` for orchestrator discovery
 
 **Standard agent correlation flags:** `--agent-id`, `--session-id`, `--request-id`, `--conversation-id`
 
@@ -99,7 +99,7 @@ Run `nget --help` for the full flag reference.
 
 ## A2A discovery
 
-n-get publishes an [A2A 0.3.0](https://a2aprotocol.ai) agent card — the standard that lets AI orchestrators (LangChain, AWS Bedrock AgentCore, Spring AI, etc.) discover and invoke agents automatically.
+n-get publishes an [A2A 1.0](https://a2aprotocol.ai) agent card — the standard that lets AI orchestrators (LangChain, AWS Bedrock AgentCore, Spring AI, etc.) discover and invoke agents automatically.
 
 ```bash
 # output the agent card JSON
@@ -113,7 +113,7 @@ Or fetch it over MCP without leaving your agent loop:
 
 ```javascript
 // MCP tool
-get_agent_card()  // returns A2A 0.3.0 JSON
+get_agent_card()  // returns A2A 1.0 JSON
 ```
 
 The card is generated live from `--capabilities` — it never drifts from what n-get actually supports. Skills exposed: `download`, `batch_download`, `fetch`.
@@ -143,7 +143,7 @@ The MCP server exposes 10 tools for direct agent control:
 | `set_profile` | Apply a config profile (fast/secure/bulk/careful) |
 | `get_history` | Flat download history with filtering |
 | `get_instructions` | Return AGENTS.md — the full agent guide |
-| `get_agent_card` | Return the A2A 0.3.0 agent card JSON |
+| `get_agent_card` | Return the A2A 1.0 agent card JSON |
 
 ## Configuration
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -195,6 +195,9 @@ profiles:
 webhooks:
   default: []                 # Array of webhook URLs for all nget runs on this machine
   secret: ''                  # HMAC-SHA256 signing secret. When set, all webhook POSTs include X-NGet-Signature: sha256=<hex>.
+  retry:
+    maxAttempts: 3            # Max delivery attempts per webhook POST (1 = no retry)
+    backoffMs: [0, 500, 1000] # Delay before each attempt in ms (length must equal maxAttempts)
 
 # Development and Debugging
 development:

--- a/index.js
+++ b/index.js
@@ -371,7 +371,7 @@ async function main() {
         if (argv._.length > 0 && argv._[0] === 'fetch') {
             const fetchUrl = argv._[1];
             if (!fetchUrl) {
-                console.error('Error: fetch requires a URL. Usage: nget fetch [--method GET] [--data <json>] [--header "Key: Value"] <url>');
+                console.error('Error: fetch requires a URL. Usage: nget fetch [--method GET] [--data <json>] [--header "Key: Value"] [--header "Key2: Value2"] <url>');
                 process.exit(1);
             }
             // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -388,10 +388,12 @@ async function main() {
             }
             const headers = {};
             if (argv.header) {
-                const headerStr = argv.header;
-                const colonIdx = headerStr.indexOf(':');
-                if (colonIdx > 0) {
-                    headers[headerStr.slice(0, colonIdx).trim()] = headerStr.slice(colonIdx + 1).trim();
+                const rawH = Array.isArray(argv.header) ? argv.header : [argv.header];
+                for (const h of rawH) {
+                    const colonIdx = h.indexOf(':');
+                    if (colonIdx > 0) {
+                        headers[h.slice(0, colonIdx).trim()] = h.slice(colonIdx + 1).trim();
+                    }
                 }
             }
             const fetchSessionId = argv['session-id'] || `fetch_${Date.now()}`;

--- a/index.ts
+++ b/index.ts
@@ -359,7 +359,7 @@ async function main(): Promise<void> {
         if (argv._.length > 0 && argv._[0] === 'fetch') {
             const fetchUrl = argv._[1] as string | undefined;
             if (!fetchUrl) {
-                console.error('Error: fetch requires a URL. Usage: nget fetch [--method GET] [--data <json>] [--header "Key: Value"] <url>');
+                console.error('Error: fetch requires a URL. Usage: nget fetch [--method GET] [--data <json>] [--header "Key: Value"] [--header "Key2: Value2"] <url>');
                 process.exit(1);
             }
             // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -371,10 +371,12 @@ async function main(): Promise<void> {
             }
             const headers: Record<string, string> = {};
             if (argv.header) {
-                const headerStr = argv.header as string;
-                const colonIdx = headerStr.indexOf(':');
-                if (colonIdx > 0) {
-                    headers[headerStr.slice(0, colonIdx).trim()] = headerStr.slice(colonIdx + 1).trim();
+                const rawH = Array.isArray(argv.header) ? argv.header : [argv.header];
+                for (const h of rawH as string[]) {
+                    const colonIdx = h.indexOf(':');
+                    if (colonIdx > 0) {
+                        headers[h.slice(0, colonIdx).trim()] = h.slice(colonIdx + 1).trim();
+                    }
                 }
             }
 

--- a/lib/core/DownloadSession.js
+++ b/lib/core/DownloadSession.js
@@ -90,6 +90,9 @@ class DownloadSession {
             pipeMode: this.pipeMode,
             ui: options.ui ?? null,
             webhooks: options.webhooks ?? [],
+            webhookSecret: this.configManager?.get('webhooks.secret') ?? '',
+            webhookMaxAttempts: this.configManager?.get('webhooks.retry.maxAttempts') ?? undefined,
+            webhookBackoffMs: this.configManager?.get('webhooks.retry.backoffMs') ?? undefined,
         });
         this.logger = this._buildLogger();
         this.securityService = this._buildSecurity();

--- a/lib/core/DownloadSession.ts
+++ b/lib/core/DownloadSession.ts
@@ -89,11 +89,14 @@ export class DownloadSession {
         this.startTime     = Date.now();
 
         this.emitter = new EventSink({
-            sessionId: this.id,
-            humanMode: this.humanMode,
-            pipeMode:  this.pipeMode,
-            ui:        options.ui ?? null,
-            webhooks:  options.webhooks ?? [],
+            sessionId:           this.id,
+            humanMode:           this.humanMode,
+            pipeMode:            this.pipeMode,
+            ui:                  options.ui ?? null,
+            webhooks:            options.webhooks ?? [],
+            webhookSecret:       (this.configManager?.get('webhooks.secret')             as string)   ?? '',
+            webhookMaxAttempts:  (this.configManager?.get('webhooks.retry.maxAttempts') as number)   ?? undefined,
+            webhookBackoffMs:    (this.configManager?.get('webhooks.retry.backoffMs')   as number[]) ?? undefined,
         });
 
         this.logger          = this._buildLogger();

--- a/lib/core/EventSink.js
+++ b/lib/core/EventSink.js
@@ -46,9 +46,9 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.EventSink = exports.EVENT = void 0;
 const crypto = __importStar(require("node:crypto"));
 const promises_1 = require("node:timers/promises");
-// ─── Webhook retry constants ──────────────────────────────────────────────────
-const MAX_ATTEMPTS = 3;
-const BACKOFF_MS = [0, 500, 1000];
+// ─── Webhook retry defaults ───────────────────────────────────────────────────
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_MS = [0, 500, 1000];
 exports.EVENT = {
     SESSION_START: 'session_start',
     SESSION_END: 'session_end',
@@ -73,6 +73,8 @@ class EventSink {
     _out;
     _webhooks;
     _webhookSecret;
+    _maxAttempts;
+    _backoffMs;
     _inflight = [];
     constructor(options) {
         this.sessionId = options.sessionId;
@@ -81,6 +83,8 @@ class EventSink {
         this.ui = options.ui ?? null;
         this._webhooks = options.webhooks ?? [];
         this._webhookSecret = options.webhookSecret ?? '';
+        this._maxAttempts = options.webhookMaxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+        this._backoffMs = options.webhookBackoffMs ?? DEFAULT_BACKOFF_MS;
         // Route events to the right stream
         this._out = (this.humanMode || this.pipeMode)
             ? process.stderr
@@ -127,9 +131,9 @@ class EventSink {
                 ...sigHeaders,
             };
             const p = (async () => {
-                for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-                    if (BACKOFF_MS[attempt] > 0) {
-                        await (0, promises_1.setTimeout)(BACKOFF_MS[attempt]);
+                for (let attempt = 0; attempt < this._maxAttempts; attempt++) {
+                    if (this._backoffMs[attempt] > 0) {
+                        await (0, promises_1.setTimeout)(this._backoffMs[attempt]);
                     }
                     const controller = new AbortController();
                     const timer = setTimeout(() => controller.abort(), 2000);
@@ -148,10 +152,10 @@ class EventSink {
                         }
                         if (res.status >= 500) {
                             // 5xx — server error, retry unless last attempt
-                            if (attempt < MAX_ATTEMPTS - 1) {
+                            if (attempt < this._maxAttempts - 1) {
                                 continue;
                             }
-                            process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${MAX_ATTEMPTS} attempts: HTTP ${res.status}\n`);
+                            process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${this._maxAttempts} attempts: HTTP ${res.status}\n`);
                             return;
                         }
                         // 1xx/2xx/3xx — success or redirect, done
@@ -160,11 +164,11 @@ class EventSink {
                     catch (err) {
                         clearTimeout(timer);
                         // Network error — retry unless last attempt
-                        if (attempt < MAX_ATTEMPTS - 1) {
+                        if (attempt < this._maxAttempts - 1) {
                             continue;
                         }
                         const message = err instanceof Error ? err.message : String(err);
-                        process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${MAX_ATTEMPTS} attempts: ${message}\n`);
+                        process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${this._maxAttempts} attempts: ${message}\n`);
                     }
                 }
             })();

--- a/lib/core/EventSink.ts
+++ b/lib/core/EventSink.ts
@@ -24,9 +24,9 @@ import type {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type UIManager = any;
 
-// ─── Webhook retry constants ──────────────────────────────────────────────────
-const MAX_ATTEMPTS = 3;
-const BACKOFF_MS = [0, 500, 1000];
+// ─── Webhook retry defaults ───────────────────────────────────────────────────
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_MS   = [0, 500, 1000];
 
 export const EVENT: Record<string, NgetEventType> = {
     SESSION_START:      'session_start',
@@ -53,6 +53,10 @@ export interface NgetEmitterOptions {
     webhooks?: WebhookConfig[];
     /** HMAC-SHA256 secret. When set, all webhook POSTs include `X-NGet-Signature: sha256=<hex>`. */
     webhookSecret?: string;
+    /** Max webhook delivery attempts (default: 3). */
+    webhookMaxAttempts?: number;
+    /** Backoff delays in ms per attempt (default: [0, 500, 1000]). */
+    webhookBackoffMs?: number[];
 }
 
 export class EventSink {
@@ -64,6 +68,8 @@ export class EventSink {
     private readonly _out: NodeJS.WriteStream;
     private readonly _webhooks: WebhookConfig[];
     private readonly _webhookSecret: string;
+    private readonly _maxAttempts: number;
+    private readonly _backoffMs: number[];
     private readonly _inflight: Promise<void>[] = [];
 
     constructor(options: NgetEmitterOptions) {
@@ -71,8 +77,10 @@ export class EventSink {
         this.humanMode     = options.humanMode     ?? false;
         this.pipeMode      = options.pipeMode      ?? false;
         this.ui            = options.ui            ?? null;
-        this._webhooks     = options.webhooks      ?? [];
-        this._webhookSecret = options.webhookSecret ?? '';
+        this._webhooks     = options.webhooks           ?? [];
+        this._webhookSecret = options.webhookSecret    ?? '';
+        this._maxAttempts  = options.webhookMaxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+        this._backoffMs    = options.webhookBackoffMs   ?? DEFAULT_BACKOFF_MS;
 
         // Route events to the right stream
         this._out = (this.humanMode || this.pipeMode)
@@ -129,9 +137,9 @@ export class EventSink {
             };
 
             const p = (async () => {
-                for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-                    if (BACKOFF_MS[attempt] > 0) {
-                        await sleep(BACKOFF_MS[attempt]);
+                for (let attempt = 0; attempt < this._maxAttempts; attempt++) {
+                    if (this._backoffMs[attempt] > 0) {
+                        await sleep(this._backoffMs[attempt]);
                     }
                     const controller = new AbortController();
                     const timer = setTimeout(() => controller.abort(), 2000);
@@ -150,8 +158,8 @@ export class EventSink {
                         }
                         if (res.status >= 500) {
                             // 5xx — server error, retry unless last attempt
-                            if (attempt < MAX_ATTEMPTS - 1) { continue; }
-                            process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${MAX_ATTEMPTS} attempts: HTTP ${res.status}\n`);
+                            if (attempt < this._maxAttempts - 1) { continue; }
+                            process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${this._maxAttempts} attempts: HTTP ${res.status}\n`);
                             return;
                         }
                         // 1xx/2xx/3xx — success or redirect, done
@@ -159,9 +167,9 @@ export class EventSink {
                     } catch (err: unknown) {
                         clearTimeout(timer);
                         // Network error — retry unless last attempt
-                        if (attempt < MAX_ATTEMPTS - 1) { continue; }
+                        if (attempt < this._maxAttempts - 1) { continue; }
                         const message = err instanceof Error ? err.message : String(err);
-                        process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${MAX_ATTEMPTS} attempts: ${message}\n`);
+                        process.stderr.write(`[nget] webhook POST to ${wh.url} failed after ${this._maxAttempts} attempts: ${message}\n`);
                     }
                 }
             })();

--- a/lib/mcp/server.js
+++ b/lib/mcp/server.js
@@ -347,7 +347,49 @@ function createServer() {
         }
     });
     // ── get_agent_card ────────────────────────────────────────────────────────
-    server.tool('get_agent_card', 'Return the A2A 0.3.0 agent card for n-get. Describes agent skills, transport, and protocol version for A2A-compatible orchestrators.', {
+    // ── fetch_http ────────────────────────────────────────────────────────────
+    server.tool('fetch_http', 'Make an HTTP API call (GET/POST/PUT/DELETE/PATCH) and return the response as JSON. Use this to call external APIs without leaving the MCP loop.', {
+        url: z.string().describe('The URL to fetch'),
+        method: z.enum(['GET', 'POST', 'PUT', 'DELETE', 'PATCH']).optional().default('GET').describe('HTTP method'),
+        body: z.string().optional().describe('Request body (JSON string for POST/PUT/PATCH)'),
+        headers: z.record(z.string()).optional().describe('Additional request headers'),
+        timeout: z.number().optional().describe('Request timeout in milliseconds (default: 30000)'),
+    }, async ({ url, method = 'GET', body, headers, timeout }) => {
+        const ngetFetch = require('../fetch');
+        try {
+            let parsedBody = body;
+            if (body) {
+                try {
+                    parsedBody = JSON.parse(body);
+                }
+                catch {
+                    parsedBody = body;
+                }
+            }
+            const result = await ngetFetch(url, { method, headers, body: parsedBody, timeout });
+            return {
+                content: [{ type: 'text', text: JSON.stringify({
+                            status: result.status,
+                            statusText: result.statusText,
+                            latencyMs: result.latencyMs,
+                            headers: result.headers,
+                            data: result.data,
+                        }) }],
+            };
+        }
+        catch (err) {
+            const e = err;
+            return {
+                isError: true,
+                content: [{ type: 'text', text: JSON.stringify({
+                            error: e.message,
+                            status: e.status,
+                        }) }],
+            };
+        }
+    });
+    // ── get_agent_card ────────────────────────────────────────────────────────
+    server.tool('get_agent_card', 'Return the A2A 1.0 agent card for n-get. Describes agent skills, transport, and protocol version for A2A-compatible orchestrators.', {
         endpoint_url: z.string().optional().describe('Override the default endpoint URL in the card (e.g. the public URL of your n-get MCP endpoint)'),
     }, ({ endpoint_url }) => {
         const caps = new CapabilitiesService({});

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -431,9 +431,55 @@ export function createServer() {
 
     // ── get_agent_card ────────────────────────────────────────────────────────
 
+    // ── fetch_http ────────────────────────────────────────────────────────────
+
+    server.tool(
+        'fetch_http',
+        'Make an HTTP API call (GET/POST/PUT/DELETE/PATCH) and return the response as JSON. Use this to call external APIs without leaving the MCP loop.',
+        {
+            url:     (z as any).string().describe('The URL to fetch'),
+            method:  (z as any).enum(['GET', 'POST', 'PUT', 'DELETE', 'PATCH']).optional().default('GET').describe('HTTP method'),
+            body:    (z as any).string().optional().describe('Request body (JSON string for POST/PUT/PATCH)'),
+            headers: (z as any).record((z as any).string()).optional().describe('Additional request headers'),
+            timeout: (z as any).number().optional().describe('Request timeout in milliseconds (default: 30000)'),
+        },
+        async ({ url, method = 'GET', body, headers, timeout }: {
+            url: string; method?: string; body?: string; headers?: Record<string, string>; timeout?: number;
+        }) => {
+            const ngetFetch = require('../fetch');
+            try {
+                let parsedBody: unknown = body;
+                if (body) {
+                    try { parsedBody = JSON.parse(body); } catch { parsedBody = body; }
+                }
+                const result = await ngetFetch(url, { method, headers, body: parsedBody, timeout });
+                return {
+                    content: [{ type: 'text' as const, text: JSON.stringify({
+                        status:      result.status,
+                        statusText:  result.statusText,
+                        latencyMs:   result.latencyMs,
+                        headers:     result.headers,
+                        data:        result.data,
+                    }) }],
+                };
+            } catch (err: unknown) {
+                const e = err as Error & { status?: number };
+                return {
+                    isError: true,
+                    content: [{ type: 'text' as const, text: JSON.stringify({
+                        error:   e.message,
+                        status:  e.status,
+                    }) }],
+                };
+            }
+        }
+    );
+
+    // ── get_agent_card ────────────────────────────────────────────────────────
+
     server.tool(
         'get_agent_card',
-        'Return the A2A 0.3.0 agent card for n-get. Describes agent skills, transport, and protocol version for A2A-compatible orchestrators.',
+        'Return the A2A 1.0 agent card for n-get. Describes agent skills, transport, and protocol version for A2A-compatible orchestrators.',
         {
             endpoint_url: (z as any).string().optional().describe('Override the default endpoint URL in the card (e.g. the public URL of your n-get MCP endpoint)'),
         },

--- a/lib/services/CapabilitiesService.js
+++ b/lib/services/CapabilitiesService.js
@@ -507,8 +507,8 @@ class CapabilitiesService {
             },
             a2a: {
                 command: 'nget --agent-card',
-                description: 'A2A 0.3.0 agent card (JSON). Describes n-get skills and transport for A2A-compatible orchestrators.',
-                protocolVersion: '0.3.0',
+                description: 'A2A 1.0 agent card (JSON). Describes n-get skills and transport for A2A-compatible orchestrators.',
+                protocolVersion: '1.0',
             }
         };
     }
@@ -556,12 +556,13 @@ class CapabilitiesService {
      */
     toA2ACard(endpointUrl) {
         return {
+            id: 'n-get',
             name: 'n-get',
             description: 'Observable downloads for AI agents — NDJSON event stream, webhook forwarding, HTTP + SFTP.',
             version: this.version,
-            protocolVersion: '0.3.0',
+            protocolVersion: '1.0',
             url: endpointUrl || 'https://your-host/a2a',
-            preferredTransport: 'JSONRPC',
+            interfaces: ['JSONRPC'],
             capabilities: { streaming: true },
             defaultInputModes: ['application/json'],
             defaultOutputModes: ['application/json', 'text/event-stream'],

--- a/lib/services/CapabilitiesService.ts
+++ b/lib/services/CapabilitiesService.ts
@@ -562,8 +562,8 @@ class CapabilitiesService {
             },
             a2a: {
                 command:     'nget --agent-card',
-                description: 'A2A 0.3.0 agent card (JSON). Describes n-get skills and transport for A2A-compatible orchestrators.',
-                protocolVersion: '0.3.0',
+                description: 'A2A 1.0 agent card (JSON). Describes n-get skills and transport for A2A-compatible orchestrators.',
+                protocolVersion: '1.0',
             }
         };
     }
@@ -613,12 +613,13 @@ class CapabilitiesService {
      */
     toA2ACard(endpointUrl?: string): AnyObj {
         return {
+            id:          'n-get',
             name:        'n-get',
             description: 'Observable downloads for AI agents — NDJSON event stream, webhook forwarding, HTTP + SFTP.',
             version:     this.version,
-            protocolVersion: '0.3.0',
+            protocolVersion: '1.0',
             url:         endpointUrl || 'https://your-host/a2a',
-            preferredTransport: 'JSONRPC',
+            interfaces:  ['JSONRPC'],
             capabilities: { streaming: true },
             defaultInputModes:  ['application/json'],
             defaultOutputModes: ['application/json', 'text/event-stream'],

--- a/site/index.html
+++ b/site/index.html
@@ -337,7 +337,7 @@
   <section id="a2a" aria-labelledby="a2a-heading">
     <h2 id="a2a-heading">Agent discovery</h2>
     <h3>Agent card</h3>
-    <p>Publish a standard A2A 0.3.0 agent card and compatible orchestrators discover and invoke n-get automatically.</p>
+    <p>Publish a standard A2A 1.0 agent card and compatible orchestrators discover and invoke n-get automatically.</p>
 
     <pre><code><span class="dim"># output the card</span>
 <span class="hi">nget</span> <span class="flag">--agent-card</span>

--- a/site/index.html
+++ b/site/index.html
@@ -372,6 +372,7 @@
           <tr><td>get_history</td>       <td>Download history with status and time filters</td></tr>
           <tr><td>get_capabilities</td>  <td>Full capabilities document</td></tr>
           <tr><td>get_instructions</td>  <td>AGENTS.md — the complete agent guide</td></tr>
+          <tr><td>fetch_http</td>        <td>HTTP API call (GET/POST/PUT/DELETE/PATCH) without leaving the MCP loop</td></tr>
           <tr><td>get_agent_card</td>    <td>Agent card — serve at /.well-known/agent.json</td></tr>
         </tbody>
       </table>
@@ -430,9 +431,12 @@
     <pre><code><span class="dim"># download</span>
 <span class="hi">nget</span> https://example.com/model.bin <span class="flag">-d</span> ./data <span class="flag">--agent-id</span> my-agent
 
-<span class="dim"># HTTP API call</span>
+<span class="dim"># HTTP API call — structured JSON response, same event stream as downloads</span>
 <span class="hi">nget fetch</span> https://api.example.com/data.json
-<span class="hi">nget fetch</span> <span class="flag">--method POST --data</span> <span class="flag">'{"key":"val"}'</span> https://api.example.com/endpoint
+<span class="hi">nget fetch</span> <span class="flag">--method POST</span> \
+     <span class="flag">--header</span> <span class="flag">'Authorization: Bearer $TOKEN'</span> \
+     <span class="flag">--header</span> <span class="flag">'Content-Type: application/json'</span> \
+     <span class="flag">--data</span> <span class="flag">'{"key":"val"}'</span> https://api.example.com/endpoint
 
 <span class="dim"># SFTP</span>
 <span class="hi">nget</span> sftp://user@host/path/file.tar.gz <span class="flag">--ssh-key</span> ~/.ssh/id_ed25519

--- a/test/a2aCardSpec.js
+++ b/test/a2aCardSpec.js
@@ -1,10 +1,10 @@
 'use strict';
 /**
- * @fileoverview Tests for Feature 2 — A2A Agent Card.
+ * @fileoverview Tests for A2A 1.0 Agent Card.
  *
  * Covers:
- *   1. toA2ACard() returns valid JSON with protocolVersion: '0.3.0'
- *   2. Required top-level fields: name, description, url, preferredTransport, skills
+ *   1. toA2ACard() returns valid JSON with protocolVersion: '1.0'
+ *   2. Required top-level fields: id, name, description, url, interfaces, skills
  *   3. All 3 skills present (download, batch_download, fetch) with id, name, description, tags
  *   4. get_agent_card MCP tool returns same structure
  *   5. --capabilities discovery section includes the a2a key
@@ -43,10 +43,10 @@ describe('A2A Agent Card', () => {
 
     // ── 1. protocolVersion ────────────────────────────────────────────────────
 
-    it('toA2ACard() returns an object with protocolVersion "0.3.0"', () => {
+    it('toA2ACard() returns an object with protocolVersion "1.0"', () => {
         const svc  = new CapabilitiesService();
         const card = svc.toA2ACard();
-        expect(card).to.have.property('protocolVersion', '0.3.0');
+        expect(card).to.have.property('protocolVersion', '1.0');
     });
 
     // ── 2. Required top-level fields ──────────────────────────────────────────
@@ -54,10 +54,16 @@ describe('A2A Agent Card', () => {
     it('toA2ACard() includes all required top-level fields', () => {
         const svc  = new CapabilitiesService();
         const card = svc.toA2ACard();
-        const required = ['name', 'description', 'url', 'preferredTransport', 'skills'];
+        const required = ['id', 'name', 'description', 'url', 'interfaces', 'skills'];
         for (const field of required) {
             expect(card, `missing field: ${field}`).to.have.property(field);
         }
+    });
+
+    it('toA2ACard() id is "n-get"', () => {
+        const svc  = new CapabilitiesService();
+        const card = svc.toA2ACard();
+        expect(card.id).to.equal('n-get');
     });
 
     it('toA2ACard() name is "n-get"', () => {
@@ -66,10 +72,11 @@ describe('A2A Agent Card', () => {
         expect(card.name).to.equal('n-get');
     });
 
-    it('toA2ACard() preferredTransport is "JSONRPC"', () => {
+    it('toA2ACard() interfaces is an array containing "JSONRPC"', () => {
         const svc  = new CapabilitiesService();
         const card = svc.toA2ACard();
-        expect(card.preferredTransport).to.equal('JSONRPC');
+        expect(card.interfaces).to.be.an('array');
+        expect(card.interfaces).to.include('JSONRPC');
     });
 
     it('toA2ACard() version comes from package.json', () => {
@@ -141,11 +148,11 @@ describe('A2A Agent Card', () => {
 
     // ── 4. MCP get_agent_card tool ─────────────────────────────────────────────
 
-    it('get_agent_card MCP tool returns object with protocolVersion "0.3.0"', async () => {
+    it('get_agent_card MCP tool returns object with protocolVersion "1.0"', async () => {
         const { client, cleanup } = await connect();
         try {
             const card = await callTool(client, 'get_agent_card');
-            expect(card).to.have.property('protocolVersion', '0.3.0');
+            expect(card).to.have.property('protocolVersion', '1.0');
         } finally {
             await cleanup();
         }
@@ -155,7 +162,7 @@ describe('A2A Agent Card', () => {
         const { client, cleanup } = await connect();
         try {
             const card = await callTool(client, 'get_agent_card');
-            const required = ['name', 'description', 'url', 'preferredTransport', 'skills'];
+            const required = ['id', 'name', 'description', 'url', 'interfaces', 'skills'];
             for (const field of required) {
                 expect(card, `missing field from MCP tool: ${field}`).to.have.property(field);
             }
@@ -187,10 +194,10 @@ describe('A2A Agent Card', () => {
         expect(disc).to.have.property('a2a');
     });
 
-    it('discovery.a2a.protocolVersion is "0.3.0"', () => {
+    it('discovery.a2a.protocolVersion is "1.0"', () => {
         const svc  = new CapabilitiesService();
         const disc = svc.getDiscoveryInfo();
-        expect(disc.a2a).to.have.property('protocolVersion', '0.3.0');
+        expect(disc.a2a).to.have.property('protocolVersion', '1.0');
     });
 
     it('discovery.a2a.command references --agent-card flag', () => {

--- a/test/fetchHttpMcpSpec.js
+++ b/test/fetchHttpMcpSpec.js
@@ -1,0 +1,182 @@
+'use strict';
+/**
+ * fetch_http MCP tool — integration spec.
+ *
+ * Uses a local echo server that reflects method, headers, and body back
+ * so tests can freely vary inputs without pre-baked routes.
+ *
+ * Covers:
+ *   - All five HTTP methods (GET POST PUT DELETE PATCH)
+ *   - JSON body round-trip
+ *   - Custom header passthrough
+ *   - Error response passthrough (4xx / 5xx still resolve, not throw)
+ *   - Network failure (unreachable host) returns error shape
+ *   - Response shape contract: status, statusText, latencyMs, headers, data
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as http from 'node:http';
+
+const { createServer }      = await import('../lib/mcp/server.js');
+const { InMemoryTransport } = await import('@modelcontextprotocol/sdk/inMemory.js');
+const { Client }            = await import('@modelcontextprotocol/sdk/client/index.js');
+
+// ─── Echo server ──────────────────────────────────────────────────────────────
+// Reflects method, headers, body, and query back as JSON.
+// Status is controlled via ?status=NNN (default 200).
+
+let server;
+let base;
+
+beforeAll(() => new Promise((resolve) => {
+    server = http.createServer((req, res) => {
+        let raw = '';
+        req.on('data', chunk => { raw += chunk; });
+        req.on('end', () => {
+            const url    = new URL(req.url, 'http://localhost');
+            const status = parseInt(url.searchParams.get('status') ?? '200', 10);
+            let body;
+            try { body = raw ? JSON.parse(raw) : null; } catch { body = raw || null; }
+            res.writeHead(status, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+                method:  req.method,
+                headers: req.headers,
+                body,
+            }));
+        });
+    });
+    server.listen(0, '127.0.0.1', () => {
+        base = `http://127.0.0.1:${server.address().port}`;
+        resolve();
+    });
+}));
+
+afterAll(() => new Promise(resolve => server.close(resolve)));
+
+// ─── MCP helpers ──────────────────────────────────────────────────────────────
+
+async function connect() {
+    const mcpServer = createServer();
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'test-client', version: '0.0.1' });
+    await Promise.all([
+        mcpServer.connect(serverTransport),
+        client.connect(clientTransport),
+    ]);
+    return { client, cleanup: async () => { await client.close(); } };
+}
+
+async function fetch_http(client, args) {
+    const result = await client.callTool({ name: 'fetch_http', arguments: args });
+    const text   = result.content.find(c => c.type === 'text')?.text ?? '{}';
+    return JSON.parse(text);
+}
+
+// ─── Response shape ───────────────────────────────────────────────────────────
+
+describe('fetch_http — response shape', () => {
+    it('always returns status, statusText, latencyMs, headers, data', async () => {
+        const { client, cleanup } = await connect();
+        try {
+            const res = await fetch_http(client, { url: `${base}/` });
+            expect(res).toHaveProperty('status');
+            expect(res).toHaveProperty('statusText');
+            expect(res).toHaveProperty('latencyMs');
+            expect(res).toHaveProperty('headers');
+            expect(res).toHaveProperty('data');
+            expect(typeof res.latencyMs).toBe('number');
+            expect(res.latencyMs).toBeGreaterThanOrEqual(0);
+        } finally { await cleanup(); }
+    });
+});
+
+// ─── HTTP methods ─────────────────────────────────────────────────────────────
+
+describe('fetch_http — HTTP methods', () => {
+    for (const method of ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']) {
+        it(`${method} request is sent with correct method`, async () => {
+            const { client, cleanup } = await connect();
+            try {
+                const res = await fetch_http(client, { url: `${base}/`, method });
+                expect(res.status).toBe(200);
+                expect(res.data.method).toBe(method);
+            } finally { await cleanup(); }
+        });
+    }
+});
+
+// ─── JSON body round-trip ─────────────────────────────────────────────────────
+
+describe('fetch_http — request body', () => {
+    it('POST JSON body is received and echoed back', async () => {
+        const { client, cleanup } = await connect();
+        try {
+            const payload = { agent: 'n-get-test', action: 'download', count: 3 };
+            const res = await fetch_http(client, {
+                url:    `${base}/`,
+                method: 'POST',
+                body:   JSON.stringify(payload),
+            });
+            expect(res.status).toBe(200);
+            expect(res.data.body).toEqual(payload);
+        } finally { await cleanup(); }
+    });
+
+    it('PUT with nested JSON body round-trips correctly', async () => {
+        const { client, cleanup } = await connect();
+        try {
+            const payload = { config: { retries: 3, timeout: 5000 } };
+            const res = await fetch_http(client, {
+                url:    `${base}/`,
+                method: 'PUT',
+                body:   JSON.stringify(payload),
+            });
+            expect(res.data.body).toEqual(payload);
+        } finally { await cleanup(); }
+    });
+});
+
+// ─── Custom headers ───────────────────────────────────────────────────────────
+
+describe('fetch_http — headers', () => {
+    it('custom headers are forwarded to the server', async () => {
+        const { client, cleanup } = await connect();
+        try {
+            const res = await fetch_http(client, {
+                url:     `${base}/`,
+                headers: { 'X-Agent-Id': 'my-agent', 'X-Session-Id': 'sess-123' },
+            });
+            expect(res.data.headers['x-agent-id']).toBe('my-agent');
+            expect(res.data.headers['x-session-id']).toBe('sess-123');
+        } finally { await cleanup(); }
+    });
+});
+
+// ─── Status code passthrough ──────────────────────────────────────────────────
+
+describe('fetch_http — status passthrough', () => {
+    for (const status of [400, 401, 403, 404, 422, 500, 502, 503]) {
+        it(`${status} response resolves (not throws) with correct status`, async () => {
+            const { client, cleanup } = await connect();
+            try {
+                const res = await fetch_http(client, { url: `${base}/?status=${status}` });
+                expect(res.status).toBe(status);
+            } finally { await cleanup(); }
+        });
+    }
+});
+
+// ─── Network error ────────────────────────────────────────────────────────────
+
+describe('fetch_http — network error', () => {
+    it('unreachable host returns error shape with error field', async () => {
+        const { client, cleanup } = await connect();
+        try {
+            const res = await fetch_http(client, {
+                url:     'http://127.0.0.1:1',  // nothing listening on port 1
+                timeout: 2000,
+            });
+            expect(res).toHaveProperty('error');
+            expect(typeof res.error).toBe('string');
+        } finally { await cleanup(); }
+    });
+});

--- a/test/webhookRetrySpec.js
+++ b/test/webhookRetrySpec.js
@@ -136,7 +136,55 @@ describe('webhook exponential-backoff retry', () => {
         expect(stderr.output).to.include('failed after 3 attempts');
     });
 
-    // ── 4. Success on first try ──────────────────────────────────────────────
+    // ── 4. Configurable maxAttempts ──────────────────────────────────────────
+
+    it('respects webhookMaxAttempts: 1 means no retry on 500', async () => {
+        const srv = await startStatusServer([500, 500, 500]);
+        const stdout = captureStream(process.stdout);
+        const stderr = captureStream(process.stderr);
+
+        try {
+            const emitter = new EventSink({
+                sessionId:          'max-attempts-1-test',
+                webhooks:           [{ url: `http://127.0.0.1:${srv.port}/hook` }],
+                webhookMaxAttempts: 1,
+                webhookBackoffMs:   [0],
+            });
+            emitter.emit('info', { message: 'no-retry' });
+            await emitter.flush();
+        } finally {
+            stdout.restore();
+            stderr.restore();
+        }
+
+        await srv.close();
+        expect(srv.callCount).to.equal(1);
+    });
+
+    it('respects webhookMaxAttempts: 2 makes exactly 2 attempts on repeated 500', async () => {
+        const srv = await startStatusServer([500, 500, 500]);
+        const stdout = captureStream(process.stdout);
+        const stderr = captureStream(process.stderr);
+
+        try {
+            const emitter = new EventSink({
+                sessionId:          'max-attempts-2-test',
+                webhooks:           [{ url: `http://127.0.0.1:${srv.port}/hook` }],
+                webhookMaxAttempts: 2,
+                webhookBackoffMs:   [0, 0],
+            });
+            emitter.emit('info', { message: 'two-attempts' });
+            await emitter.flush();
+        } finally {
+            stdout.restore();
+            stderr.restore();
+        }
+
+        await srv.close();
+        expect(srv.callCount).to.equal(2);
+    });
+
+    // ── 5. Success on first try ──────────────────────────────────────────────
 
     it('success on first try: makes exactly 1 call and logs nothing on 200', async () => {
         const srv = await startStatusServer([200]);


### PR DESCRIPTION
  Summary

  Upgrades the A2A agent card to the current 1.0 spec, adds fetch_http as the 11th MCP tool so agents can make API calls without leaving the MCP
   loop, and moves webhook retry settings from hardcoded constants into config. Also fixes nget fetch --header to accept multiple headers —
  found while dogfooding the new tool.

  What's in

  - A2A 1.0 — protocolVersion, id, and interfaces fields updated to match the January 2026 spec
  - fetch_http MCP tool — GET/POST/PUT/DELETE/PATCH with body, headers, timeout; returns { status, statusText, latencyMs, headers, data }
  - Webhook retry via config — webhooks.retry.maxAttempts and webhooks.retry.backoffMs in config/default.yaml; no more magic numbers in code
  - nget fetch --header repeatable — multiple --header flags now stack; authenticated API calls work as expected

  Test plan

  - npm test — 501 passing
  - npm run build — clean
  - nget fetch used to call GitHub API with 4 headers (dogfood verification)