### PR TITLE
fix: drop postversion auto-push; allow release/* in prerelease-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "hooks": "node scripts/install-hooks.js",
     "preversion": "node scripts/prerelease-check.js",
     "version": "node scripts/sync-version.js && npm run build && git add -u",
-    "postversion": "git push origin master --follow-tags",
     "build": "tsc && node scripts/gen-agents-md.js",
     "build:docs": "node scripts/gen-agents-md.js",
     "test": "vitest run",

--- a/scripts/prerelease-check.js
+++ b/scripts/prerelease-check.js
@@ -22,11 +22,11 @@ function fail(msg, hint) {
     process.exit(1);
 }
 
-// 1. Must be on master
+// 1. Must be on master or a release branch
 const branch = run('git branch --show-current');
-if (branch !== 'master') {
-    fail(`Must release from master (currently on "${branch}")`,
-         'Run: git checkout master');
+if (branch !== 'master' && !branch.startsWith('release/')) {
+    fail(`Must release from master or a release/* branch (currently on "${branch}")`,
+         'Run: git checkout -b release/x.y.z master');
 }
 
 // 2. Working tree must be clean


### PR DESCRIPTION
## Summary

- Remove `postversion` hook that auto-pushed to master — master is now branch-protected, direct pushes are rejected
- Update `prerelease-check.js` to accept `release/*` branches so `npm version` can run on a release branch

## Why

With master branch-protected (PRs required, no direct pushes), the old release flow broke in two places:
1. `postversion` hook tried to `git push origin master --follow-tags` — rejected by branch protection
2. `prerelease-check.js` required being on `master` — but releases now happen on `release/*` branches

## New release flow

```bash
git checkout -b release/x.y.z
npm version minor   # prerelease-check passes, bumps, builds, tags locally
git push origin release/x.y.z   # via token
# open PR, CEO merges
git push origin vx.y.z   # tags are not branch-protected
```

## Test plan
- [ ] `npm test` passes (947 tests)
- [ ] `npm version` on a `release/*` branch does not auto-push to master
- [ ] `prerelease-check.js` accepts `release/*`, rejects arbitrary feature branches