### PR TITLE
2.3.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # n-get — Agent Instructions
 
-**Version:** 2.3.0 · **License:** MIT · **Node:** >= 18
+**Version:** 2.3.1 · **License:** MIT · **Node:** >= 18
 
 Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n-get",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n-get",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n-get",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "homepage": "https://n-get.design-87b.workers.dev/",
   "description": "Observable downloads for AI agents. NDJSON event stream, MCP server, OpenAPI spec, session visibility, HTTP + SFTP with resume.",
   "repository": {

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@
     <span>·</span>
     <a href="https://github.com/bingeboy/n-get/issues">Issues</a>
     <span>·</span>
-    <span>v2.3.0</span>
+    <span>v2.3.1</span>
     <span>·</span>
     <span>MIT</span>
   </nav>
@@ -463,7 +463,7 @@
     <span>·</span>
     <a href="https://github.com/bingeboy/n-get/blob/master/LICENSE">MIT</a>
   </nav>
-  <span>n-get v2.3.0 · Node.js ≥ 18</span>
+  <span>n-get v2.3.1 · Node.js ≥ 18</span>
 </footer>
 
 <script>


### PR DESCRIPTION
Patch release closing every open advisory in the dependency tree. `npm audit` goes from 10 vulnerabilities (7 high, 2 moderate, 1 low) to **0**. No source changes were required — the fixes come entirely from semver-compatible dependency bumps, so there is no behavioural change and this is a drop-in upgrade from 2.3.0.